### PR TITLE
Increase the refcount on None before returning it.

### DIFF
--- a/module.c
+++ b/module.c
@@ -22,7 +22,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         if (*c >= '0' && *c <= '9')
             year = 10 * year + *c++ - '0';
         else
-            return Py_None;
+            Py_RETURN_NONE;
     }
 
     if (*c == '-') // Optional separator
@@ -33,7 +33,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         if (*c >= '0' && *c <= '9')
             month = 10 * month + *c++ - '0';
         else
-            return Py_None;
+            Py_RETURN_NONE;
     }
 
     if (*c == '-') // Optional separator
@@ -58,7 +58,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
             if (*c >= '0' && *c <= '9')
                 hour = 10 * hour + *c++ - '0';
             else
-                return Py_None;
+                Py_RETURN_NONE;
         }
 
         if (*c == ':') // Optional separator
@@ -151,7 +151,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
 
     obj = PyDateTime_FromDateAndTime(year, month, day, hour, minute, second, usecond);
     if (!obj)
-        return Py_None;
+        Py_RETURN_NONE;
 
     if (parse_tzinfo && aware && pytz_fixed_offset != NULL) {
 


### PR DESCRIPTION
This is important as when that variable falls out of scope, you're going to decrease the refcount on None.

Eventually you'll hit a zero refcount and None will be deallocated, which shouldn't ever happen.
