### PR TITLE
Removed redundant check for parse_tzinfo

### DIFF
--- a/module.c
+++ b/module.c
@@ -153,7 +153,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
     if (!obj)
         Py_RETURN_NONE;
 
-    if (parse_tzinfo && aware && pytz_fixed_offset != NULL) {
+    if (aware && pytz_fixed_offset != NULL) {
 
         PyObject* replace;
         PyObject* aware_obj;


### PR DESCRIPTION
The aware flag can only be truthy if parse_tzinfo is also truthy, so there is no need to check for parse_tzinfo if we're checking the aware flag.