### PR TITLE
Add classifier for python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ setup(
     name="ciso8601",
     version="1.0.1",
     description='Fast ISO8601 date time parser for Python written in C',
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+    ],
     ext_modules=[Extension("ciso8601", ["module.c"])],
     test_suite='tests',
     tests_require=['pytz'],


### PR DESCRIPTION
Helps tools like
https://github.com/dustinmm80/checkmyreqs and https://caniusepython3.com/project/ciso8601
to identify python 3 compatability