### PR TITLE
Include license information in sdists.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include LICENSE
 include README.md

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name="ciso8601",
     version="1.0.1",
     description='Fast ISO8601 date time parser for Python written in C',
+    license="MIT",
     ext_modules=[Extension("ciso8601", ["module.c"])],
     test_suite='tests',
     tests_require=['pytz'],


### PR DESCRIPTION
Today people who download the package from pip don't have any information about the package's license.  There isn't any information about that in the README, or other package metadata.  This branch adds the full license to sdists, plus adds license information to setup.py for convenience, so everyone can know exactly what the terms are.