### PR TITLE
Return None for invalid day

### DIFF
--- a/module.c
+++ b/module.c
@@ -52,7 +52,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
     if (day == 0) day = 1; // YYYY-MM format
 
     // Validate max day based on month
-    switch(month) {
+    switch (month) {
         case 1:
             if (day > 31)
                 Py_RETURN_NONE;

--- a/module.c
+++ b/module.c
@@ -51,6 +51,69 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
 
     if (day == 0) day = 1; // YYYY-MM format
 
+    // In the Gregorian calendar three criteria must be taken into account to identify leap years:
+    // * The year can be evenly divided by 4;
+    // * If the year can be evenly divided by 100, it is NOT a leap year, unless;
+    // * The year is also evenly divisible by 400. Then it is a leap year.
+    unsigned int leap = (year % 4 == 0) && (year % 100 || (year % 400 == 0));
+
+    // Validate max day based on month
+    switch(month) {
+        case 1:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+        case 2:
+            if (leap > 0) {
+                if (day > 29)
+                    Py_RETURN_NONE;
+            } else {
+                if (day > 28)
+                    Py_RETURN_NONE;
+            }
+            break;
+        case 3:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+        case 4:
+            if (day > 30)
+                Py_RETURN_NONE;
+            break;
+        case 5:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+        case 6:
+            if (day > 30)
+                Py_RETURN_NONE;
+            break;
+        case 7:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+        case 8:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+        case 9:
+            if (day > 30)
+                Py_RETURN_NONE;
+            break;
+        case 10:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+        case 11:
+            if (day > 30)
+                Py_RETURN_NONE;
+            break;
+        case 12:
+            if (day > 31)
+                Py_RETURN_NONE;
+            break;
+    }
+
     if (*c == 'T' || *c == ' ') // Time separator
     {
         c++;

--- a/module.c
+++ b/module.c
@@ -51,12 +51,6 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
 
     if (day == 0) day = 1; // YYYY-MM format
 
-    // In the Gregorian calendar three criteria must be taken into account to identify leap years:
-    // * The year can be evenly divided by 4;
-    // * If the year can be evenly divided by 100, it is NOT a leap year, unless;
-    // * The year is also evenly divisible by 400. Then it is a leap year.
-    unsigned int leap = (year % 4 == 0) && (year % 100 || (year % 400 == 0));
-
     // Validate max day based on month
     switch(month) {
         case 1:
@@ -64,12 +58,15 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
                 Py_RETURN_NONE;
             break;
         case 2:
-            if (leap > 0) {
-                if (day > 29)
+            // In the Gregorian calendar three criteria must be taken into account to identify leap years:
+            // * The year can be evenly divided by 4;
+            // * If the year can be evenly divided by 100, it is NOT a leap year, unless;
+            // * The year is also evenly divisible by 400. Then it is a leap year.
+            if (day > 28) {
+                unsigned int leap = (year % 4 == 0) && (year % 100 || (year % 400 == 0));
+                if (leap == 0 || day > 29) {
                     Py_RETURN_NONE;
-            } else {
-                if (day > 28)
-                    Py_RETURN_NONE;
+                }
             }
             break;
         case 3:

--- a/tests.py
+++ b/tests.py
@@ -59,10 +59,11 @@ class CISO8601TestCase(unittest.TestCase):
             ciso8601.parse_datetime('20140203T103527.234567891234'),
             datetime.datetime(2014, 2, 3, 10, 35, 27, 234567)
         )
-        self.assertEqual(
-            ciso8601.parse_datetime_unaware('2016-02-29'),  # 2016 is a leap year
-            datetime.datetime(2016, 2, 29, 0, 0, 0, 0)
-        )
+        for leap_year in (1600, 2000, 2016):
+            self.assertEqual(
+                ciso8601.parse_datetime_unaware('{}-02-29'.format(leap_year)),
+                datetime.datetime(leap_year, 2, 29, 0, 0, 0, 0)
+            )
 
     def test_aware_utc(self):
         expected = datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.UTC)
@@ -143,10 +144,11 @@ class CISO8601TestCase(unittest.TestCase):
             ciso8601.parse_datetime_unaware('2014-01-32'),
             None,
         )
-        self.assertEqual(
-            ciso8601.parse_datetime_unaware('2014-02-29'),  # 2014 is not a leap year
-            None,
-        )
+        for non_leap_year in (1700, 1800, 1900, 2014):
+            self.assertEqual(
+                ciso8601.parse_datetime_unaware('{}-02-29'.format(non_leap_year)),
+                None,
+            )
         self.assertEqual(
             ciso8601.parse_datetime_unaware('Z'),
             None,

--- a/tests.py
+++ b/tests.py
@@ -59,6 +59,10 @@ class CISO8601TestCase(unittest.TestCase):
             ciso8601.parse_datetime('20140203T103527.234567891234'),
             datetime.datetime(2014, 2, 3, 10, 35, 27, 234567)
         )
+        self.assertEqual(
+            ciso8601.parse_datetime_unaware('2016-02-29'),  # 2016 is a leap year
+            datetime.datetime(2016, 2, 29, 0, 0, 0, 0)
+        )
 
     def test_aware_utc(self):
         expected = datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.UTC)
@@ -133,6 +137,14 @@ class CISO8601TestCase(unittest.TestCase):
         )
         self.assertEqual(
             ciso8601.parse_datetime('20140203T23:35:61'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime_unaware('2014-01-32'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime_unaware('2014-02-29'),  # 2014 is not a leap year
             None,
         )
         self.assertEqual(


### PR DESCRIPTION
Like #21, but improved leap year tests.