### PR TITLE
Use public pytz.FixedOffset method for getting timezone offsets

### DIFF
--- a/module.c
+++ b/module.c
@@ -310,7 +310,7 @@ initciso8601(void)
     }
     else
     {
-        pytz_fixed_offset = PyObject_GetAttrString(pytz, "_FixedOffset");
+        pytz_fixed_offset = PyObject_GetAttrString(pytz, "FixedOffset");
         pytz_utc = PyObject_GetAttrString(pytz, "UTC");
     }
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
This one character change gives quite a large speed up when processing times which are timezone aware. 

The [public `pytz.FixedOffset` method](https://github.com/stub42/pytz/blob/8e941cf012078fd55ca00db9aa5f0d981137a343/src/pytz/__init__.py#L415-L479) holds a cache of `FixedOffset` objects created in the `_tzinfos` dict variable. This reduces the number of FixedOffset objects created and dramatically speeds up parsing of timezone aware datetimes when they are in timezones already cached.

This was my test benchmark, before the change (testing on `closeio/ciso8601` master):

```
In [1]: import ciso8601

In [2]: ds = u'2014-01-09T21:48:00.921000+05:30'

In [3]: ciso8601.parse_datetime(ds)
Out[3]: datetime.datetime(2014, 1, 9, 21, 48, 0, 921000, tzinfo=pytz.FixedOffset(330))

In [4]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 2.97 µs per loop

In [5]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 2.94 µs per loop

In [6]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 3.01 µs per loop
```

After the change to use the public `pytz.FixedOffset` method:

```
In [1]: import ciso8601

In [2]: ds = u'2014-01-09T21:48:00.921000+05:30'

In [3]: ciso8601.parse_datetime(ds)
Out[3]: datetime.datetime(2014, 1, 9, 21, 48, 0, 921000, tzinfo=pytz.FixedOffset(330))

In [4]: %timeit ciso8601.parse_datetime(ds)
1000000 loops, best of 3: 1.89 µs per loop

In [5]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 1.9 µs per loop

In [6]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 1.86 µs per loop
```