### PR TITLE
Use PyDateTimeAPI rather than creating the tzinfo and calling replace

### DIFF
--- a/module.c
+++ b/module.c
@@ -6,6 +6,9 @@ static PyObject* pytz_utc;
 
 static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
 {
+    PyObject *obj;
+    PyObject* tzinfo = Py_None;
+    
     char* str = NULL;
     char* c;
     int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, usecond = 0, i = 0;
@@ -213,8 +216,6 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         }
     }
 
-    PyObject* tzinfo = Py_None;
-
     if (aware && pytz_fixed_offset != NULL) {
         tzminute += 60*tzhour;
         tzminute *= tzsign;
@@ -225,7 +226,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
             tzinfo = PyObject_CallFunction(pytz_fixed_offset, "i", tzminute);
     }
 
-    PyObject *obj = PyDateTimeAPI->DateTime_FromDateAndTime(
+    obj = PyDateTimeAPI->DateTime_FromDateAndTime(
         year,
         month,
         day,

--- a/module.c
+++ b/module.c
@@ -6,7 +6,6 @@ static PyObject* pytz_utc;
 
 static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
 {
-    PyObject *obj;
     char* str = NULL;
     char* c;
     int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, usecond = 0, i = 0;
@@ -214,46 +213,35 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         }
     }
 
-
-    obj = PyDateTime_FromDateAndTime(year, month, day, hour, minute, second, usecond);
-    if (!obj)
-        Py_RETURN_NONE;
+    PyObject* tzinfo = Py_None;
 
     if (aware && pytz_fixed_offset != NULL) {
-
-        PyObject* replace;
-        PyObject* aware_obj;
-        PyObject* args;
-        PyObject* kwargs;
-        PyObject* tzinfo = NULL;
-
         tzminute += 60*tzhour;
         tzminute *= tzsign;
 
         if (tzminute == 0)
             tzinfo = pytz_utc;
-        if (!tzinfo)
+        else
             tzinfo = PyObject_CallFunction(pytz_fixed_offset, "i", tzminute);
-        if (!tzinfo)
-            return obj;
-
-        // Assume these will succeed
-        args = PyTuple_New(0);
-        replace = PyObject_GetAttrString(obj, "replace");
-        kwargs = PyDict_New();
-        PyDict_SetItemString(kwargs, "tzinfo", tzinfo);
-        aware_obj = PyObject_Call(replace, args, kwargs);
-
-        Py_DECREF(obj);
-        Py_DECREF(replace);
-        Py_DECREF(kwargs);
-        Py_DECREF(args);
-        if (tzinfo != pytz_utc)
-            Py_DECREF(tzinfo);
-
-        obj = aware_obj;
-
     }
+
+    PyObject *obj = PyDateTimeAPI->DateTime_FromDateAndTime(
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        usecond,
+        tzinfo,
+        PyDateTimeAPI->DateTimeType
+    );
+
+    if (tzinfo != Py_None && tzinfo != pytz_utc)
+        Py_DECREF(tzinfo);
+
+    if (!obj)
+        Py_RETURN_NONE;
 
     return obj;
 }


### PR DESCRIPTION
This PR does some refactoring to make parsing timezone aware datetimes more efficient, specifically not calling replace saves a few allocations on creating the args and kwargs.

This was my test benchmark, before the change (testing on closeio/ciso8601 master):

```
In [1]: import ciso8601

In [2]: ds = u'2014-01-09T21:48:00.921000+05:30'

In [3]: ciso8601.parse_datetime(ds)
Out[3]: datetime.datetime(2014, 1, 9, 21, 48, 0, 921000, tzinfo=pytz.FixedOffset(330))

In [4]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 2.97 µs per loop

In [5]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 2.94 µs per loop

In [6]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 3.01 µs per loop
```

After this change:

```
In [1]: import ciso8601

In [2]: ds = u'2014-01-09T21:48:00.921000+05:30'

In [3]: ciso8601.parse_datetime('2014-12-05T12:30:45.123456+05:30')
Out[3]: datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, tzinfo=pytz.FixedOffset(330))

In [4]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 1.89 µs per loop

In [5]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 1.94 µs per loop

In [6]: %timeit ciso8601.parse_datetime(ds)
100000 loops, best of 3: 1.91 µs per loop
```

When combined with the optimisations in https://github.com/closeio/ciso8601/pull/27 to call the public `pytz.FixedOffset` method which has a cache, these numbers look even better:

```
In [1]: import ciso8601

In [2]: ds = u'2014-01-09T21:48:00.921000+05:30'

In [3]: ciso8601.parse_datetime('2014-12-05T12:30:45.123456+05:30')
Out[3]: datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, tzinfo=pytz.FixedOffset(330))

In [4]: %timeit ciso8601.parse_datetime(ds)
1000000 loops, best of 3: 834 ns per loop

In [5]: %timeit ciso8601.parse_datetime(ds)
1000000 loops, best of 3: 841 ns per loop

In [6]: %timeit ciso8601.parse_datetime(ds)
1000000 loops, best of 3: 831 ns per loop
```