### PR TITLE
Ensure we return None for a month of 00

### DIFF
--- a/module.c
+++ b/module.c
@@ -35,8 +35,11 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         month = *c++ - '0';
     else
         Py_RETURN_NONE;
-    if (*c >= '0' && *c <= '9' && ((month == 0 && *c > '0') || (month > 0 && *c <= '2')))
-        month = 10 * month + *c++ - '0';
+
+    if (month == 0 && *c > '0' && *c <= '9')
+        month = *c++ - '0';
+    else if (month == 1 && *c >= '0' && *c <= '2')
+        month = 10 + *c++ - '0';
     else
         Py_RETURN_NONE;
 

--- a/module.c
+++ b/module.c
@@ -8,13 +8,13 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
 {
     PyObject *obj;
     PyObject* tzinfo = Py_None;
-    
+
     char* str = NULL;
     char* c;
     int year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, usecond = 0, i = 0;
     int aware = 0; // 1 if aware
     int tzhour = 0, tzminute = 0, tzsign = 0;
- 
+
     if (!PyArg_ParseTuple(args, "s", &str))
         return NULL;
     c = str;
@@ -35,7 +35,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         month = *c++ - '0';
     else
         Py_RETURN_NONE;
-    if (*c >= '0' && *c <= '9' && (month == 0 || *c <= '2'))
+    if (*c >= '0' && *c <= '9' && ((month == 0 && *c > '0') || (month > 0 && *c <= '2')))
         month = 10 * month + *c++ - '0';
     else
         Py_RETURN_NONE;
@@ -216,12 +216,12 @@ static PyObject* parse_datetime_unaware(PyObject* self, PyObject* args)
 {
     return _parse(self, args, 0);
 }
- 
+
 static PyObject* parse_datetime(PyObject* self, PyObject* args)
 {
     return _parse(self, args, 1);
 }
- 
+
 static PyMethodDef CISO8601Methods[] =
 {
      {"parse_datetime", parse_datetime, METH_VARARGS, "Parse a ISO8601 date time string."},

--- a/tests.py
+++ b/tests.py
@@ -129,6 +129,10 @@ class CISO8601TestCase(unittest.TestCase):
             None,
         )
         self.assertEqual(
+            ciso8601.parse_datetime_unaware('2014-00-03'),
+            None,
+        )
+        self.assertEqual(
             ciso8601.parse_datetime('20140203T24:35:27'),
             None,
         )


### PR DESCRIPTION
Currently the ciso8601 library is sending back a datetime with an invalid month of 0. The CPython Datetime interface allows this but constructing the datetime manually in Python land gives you `ValueError: month must be in 1..12`.

This PR ensures that we handle this case correctly and return a None for a month which is not between 1 to 12 (with a test naturally)