### PR TITLE
Fix issue #32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 from setuptools import setup, Extension
+# workaround for open() with encoding='' python2/3 compability
+from io import open
 
-with open('README.rst') as file:
+with open('README.rst', encoding='utf-8') as file:
     long_description = file.read()
 
 setup(


### PR DESCRIPTION
Fixes #32.

I'm using the io module, which is slow because purely implemented in python, but since we are only going to use. [Via.](https://stackoverflow.com/a/10975371).

Tested on Debian Stretch with Python 2.7.13 and Python 3.6.3. Should be compatible from Python 2.6 starting.