### PR TITLE
Bump version for release v1.0.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Tested on Python 2.7.10 on macOS 10.12.6 using the following modules:
 
   aniso8601==1.2.1
   arrow==0.10.0
-  ciso8601==1.0.4
+  ciso8601==1.0.6
   iso8601==0.1.12
   isodate==0.5.4
   python-dateutil==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst', encoding='utf-8') as file:
 
 setup(
     name="ciso8601",
-    version="1.0.5",
+    version="1.0.6",
     description='Fast ISO8601 date time parser for Python written in C',
     long_description=long_description,
     license="MIT",


### PR DESCRIPTION
I've also updated the macos mention, so people use the latest version there too. Since I've never done a release before ([this is how you do it](https://help.github.com/articles/creating-releases/), basically click on "Releases" at the main-page of the Repository and then click "Draft a new release"). 

Put something like this into your release note:

- Fix bug #32 causing Python 3 `setup.py`/`pip` to fail when non-unicode locale is set in `env`
- Update instructions for macos