### PR TITLE
Fix segfault on invalid timezone information

### DIFF
--- a/module.c
+++ b/module.c
@@ -169,7 +169,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
                 if (*c >= '0' && *c <= '9')
                     tzhour = 10 * tzhour + *c++ - '0';
                 else
-                    break;
+                    Py_RETURN_NONE;
             }
 
             if (*c == ':') // Optional separator
@@ -179,7 +179,7 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
                 if (*c >= '0' && *c <= '9')
                     tzminute = 10 * tzminute + *c++ - '0';
                 else
-                    break;
+                    Py_RETURN_NONE;
             }
         }
     }

--- a/tests.py
+++ b/tests.py
@@ -145,6 +145,22 @@ class CISO8601TestCase(unittest.TestCase):
             None,
         )
         self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+99'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+FFF'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+09+00'),
+            None,
+        )
+        self.assertEqual(
             ciso8601.parse_datetime_unaware('2014-01-32'),
             None,
         )


### PR DESCRIPTION
Hello! :smile: 

Before: Parsing invalid timezone contained string causes segfault on c module.

```python
>>> ciso8601.parse_datetime('2016-01-01T00:00:00+99')
[1]    10313 segmentation fault (core dumped)  python
```

After: works -- returns None.