### PR TITLE
Test py36 in tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-# https://travis-ci.org/elasticsales/ciso8601
+# https://travis-ci.org/closeio/ciso8601
 language: python
 python:
     - 2.7
     - 3.4
-script:
-    - python setup.py test
+    - 3.5
+    - 3.6
+install: pip install tox-travis
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps=


### PR DESCRIPTION
I noticed that the tests pass in my py 3.6 environment but that it's never tested in tox. Or in travis. 