### PR TITLE
Fix segfault on incorrect TZ offset

### DIFF
--- a/module.c
+++ b/module.c
@@ -165,21 +165,28 @@ static PyObject* _parse(PyObject* self, PyObject* args, int parse_tzinfo)
         }
 
         if (tzsign != 0) {
-            for (i = 0; i < 2; i++) {
-                if (*c >= '0' && *c <= '9')
-                    tzhour = 10 * tzhour + *c++ - '0';
-                else
-                    break;
-            }
+            // TZ offset hour (00-23)
+            if (*c >= '0' && *c <= '2')
+                tzhour = *c++ - '0';
+            else
+                Py_RETURN_NONE;
+            if (*c >= '0' && *c <= '9' && (tzhour < 2 || *c <= '3'))
+                tzhour = 10 * tzhour + *c++ - '0';
+            else
+                Py_RETURN_NONE;
 
             if (*c == ':') // Optional separator
                 c++;
 
-            for (i = 0; i < 2; i++) {
+            // TZ offset minute (optional) (00-59)
+            if (*c >= '0' && *c <= '5') {
+                tzminute = *c++ - '0';
                 if (*c >= '0' && *c <= '9')
                     tzminute = 10 * tzminute + *c++ - '0';
                 else
-                    break;
+                    Py_RETURN_NONE;
+            } else if (*c >= '6' && *c <= '9') {
+                Py_RETURN_NONE;
             }
         }
     }

--- a/tests.py
+++ b/tests.py
@@ -82,6 +82,10 @@ class CISO8601TestCase(unittest.TestCase):
 
     def test_aware_offset(self):
         self.assertEqual(
+            ciso8601.parse_datetime('2014-12-05T12:30:45.123456+05'),
+            datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.FixedOffset(300))
+        )
+        self.assertEqual(
             ciso8601.parse_datetime('2014-12-05T12:30:45.123456+05:30'),
             datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.FixedOffset(330))
         )
@@ -90,8 +94,20 @@ class CISO8601TestCase(unittest.TestCase):
             datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.FixedOffset(-330))
         )
         self.assertEqual(
+            ciso8601.parse_datetime('2014-12-05T12:30:45.123456-06'),
+            datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.FixedOffset(-360))
+        )
+        self.assertEqual(
             ciso8601.parse_datetime('2014-12-05T12:30:45.123456-06:00'),
             datetime.datetime(2014, 12, 5, 12, 30, 45, 123456, pytz.FixedOffset(-360))
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('2014-12-05T00:00+23:59'),
+            datetime.datetime(2014, 12, 5, 0, 0, 0, 0, pytz.FixedOffset(1439))
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('2014-12-05T00:00-23:59'),
+            datetime.datetime(2014, 12, 5, 0, 0, 0, 0, pytz.FixedOffset(-1439))
         )
 
     def test_unaware(self):
@@ -142,6 +158,34 @@ class CISO8601TestCase(unittest.TestCase):
         )
         self.assertEqual(
             ciso8601.parse_datetime('20140203T23:35:61'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+99'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+FFF'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+23:99'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00-23:99'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00+24:00'),
+            None,
+        )
+        self.assertEqual(
+            ciso8601.parse_datetime('20140203T23:35:00-24:00'),
             None,
         )
         self.assertEqual(


### PR DESCRIPTION
Better fix for https://github.com/closeio/ciso8601/pull/36

Though this will be already fixed in v2 (https://github.com/closeio/ciso8601/pull/43), it's important to update v1 since it can cause Python to crash.

cc @yoloseem @peterbe @movermeyer