### PR TITLE
Added caching of the timezone objects

### DIFF
--- a/module.c
+++ b/module.c
@@ -358,7 +358,6 @@ _parse(PyObject *self, PyObject *args, int parse_any_tzinfo)
                         tz_cache[tz_index] = tzinfo;
                     }
                     tzinfo = tz_cache[tz_index];
-                    Py_INCREF(tzinfo);
                 }
             }
         }
@@ -381,9 +380,6 @@ _parse(PyObject *self, PyObject *args, int parse_any_tzinfo)
         Py_DECREF(delta);
         Py_DECREF(temp);
     }
-
-    if (obj && time_is_midnight)
-        obj = PyNumber_Add(obj, PyDelta_FromDSU(1, 0, 0)); /* 1 day */
 
     return obj;
 }

--- a/module.c
+++ b/module.c
@@ -355,7 +355,10 @@ _parse(PyObject *self, PyObject *args, int parse_any_tzinfo)
 #endif
                         if (tzinfo == NULL) /* ie. PyErr_Occurred() */
                             return NULL;
-                        tz_cache[tz_index] = tzinfo;
+
+                        if (tz_index < 0 || tz_index > 2878) {
+                            tz_cache[tz_index] = tzinfo;
+                        }
                     }
                     tzinfo = tz_cache[tz_index];
                 }

--- a/module.c
+++ b/module.c
@@ -356,7 +356,7 @@ _parse(PyObject *self, PyObject *args, int parse_any_tzinfo)
                         if (tzinfo == NULL) /* ie. PyErr_Occurred() */
                             return NULL;
 
-                        if (tz_index < 0 || tz_index > 2878) {
+                        if (tz_index >= 0 && tz_index <= 2878) {
                             tz_cache[tz_index] = tzinfo;
                         }
                     }


### PR DESCRIPTION
Processing multiple timestamps can be much faster, since they just use the cached timezone object instead.

Implements #47 