### PR TITLE
Fixed a problem with escaping of version number on Windows builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 <!-- TOC anchorMode:github.com -->
 
 - [2.x.x](#2xx)
+    - [Version 2.1.1 (Unreleased)](#version-211-unreleased)
     - [Version 2.1.0](#version-210)
     - [Version 2.0.1](#version-201)
     - [Version 2.0.0](#version-200)
@@ -15,6 +16,10 @@
 <!-- /TOC -->
 
 # 2.x.x
+
+## Version 2.1.1 (Unreleased)
+
+* Fixed a problem where builds on Windows were not working (#76).
 
 ## Version 2.1.0
 

--- a/module.c
+++ b/module.c
@@ -1,6 +1,8 @@
 #include <Python.h>
 #include <datetime.h>
 
+#define STRINGIZE(x) #x
+
 #define PY_VERSION_AT_LEAST_32 \
     ((PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 2) || PY_MAJOR_VERSION > 3)
 #define PY_VERSION_AT_LEAST_36 \
@@ -505,7 +507,8 @@ initciso8601(void)
     PyObject *module = Py_InitModule("ciso8601", CISO8601Methods);
 #endif
     /* CISO8601_VERSION is defined in setup.py */
-    PyModule_AddStringConstant(module, "__version__", CISO8601_VERSION);
+    PyModule_AddStringConstant(module, "__version__",
+                               STRINGIZE(CISO8601_VERSION));
 
     PyDateTime_IMPORT;
 #if PY_VERSION_AT_LEAST_37

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     license="MIT",
     ext_modules=[Extension("ciso8601",
                            sources=["module.c"],
-                           define_macros=[("CISO8601_VERSION", '"%s"' % VERSION)]
+                           define_macros=[("CISO8601_VERSION", VERSION)]
                            )],
     packages=["ciso8601"],
     package_data={"ciso8601": ["__init__.pyi", "py.typed"]},


### PR DESCRIPTION
Using the "stringizing operator" (https://docs.microsoft.com/en-us/cpp/preprocessor/stringizing-operator-hash)