### PR TITLE
Release version 2.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - test-3.5
       - test-3.6
       - test-3.7
+      - test-3.8
       - lint-rst
 
 defaults: &defaults
@@ -42,7 +43,11 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:3.7
-    
+  test-3.8:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.8
+
   lint-rst:
     working_directory: ~/code
     steps:
@@ -59,4 +64,4 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-    - image: circleci/python:3.7
+    - image: circleci/python:3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,25 @@
 <!-- TOC anchorMode:github.com -->
 
 - [2.x.x](#2xx)
-    - [Version 2.1.1](#version-211)
-    - [Version 2.1.0](#version-210)
-    - [Version 2.0.1](#version-201)
-    - [Version 2.0.0](#version-200)
-        - [Breaking changes](#breaking-changes)
-        - [Other Changes](#other-changes)
-        - [v1.x.x -> 2.0.0 Migration guide](#v1xx---200-migration-guide)
-            - [ValueError instead of None](#valueerror-instead-of-none)
-            - [Tightened ISO 8601 conformance](#tightened-iso-8601-conformance)
-            - [`parse_datetime_unaware` has been renamed](#parse_datetime_unaware-has-been-renamed)
+  - [Version 2.1.2](#version-212)
+  - [Version 2.1.1](#version-211)
+  - [Version 2.1.0](#version-210)
+  - [Version 2.0.1](#version-201)
+  - [Version 2.0.0](#version-200)
+    - [Breaking changes](#breaking-changes)
+    - [Other Changes](#other-changes)
+    - [v1.x.x -> 2.0.0 Migration guide](#v1xx---200-migration-guide)
+      - [ValueError instead of None](#valueerror-instead-of-none)
+      - [Tightened ISO 8601 conformance](#tightened-iso-8601-conformance)
+      - [`parse_datetime_unaware` has been renamed](#parsedatetimeunaware-has-been-renamed)
 
 <!-- /TOC -->
 
 # 2.x.x
+
+## Version 2.1.2
+
+* Fixed a problem where `ciso8601.__version__` was not working (#80). Thanks @ianhoffman.
 
 ## Version 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Generated with "Markdown T​O​C" extension for Visual Studio Code -->
 <!-- TOC anchorMode:github.com -->
 
+- [Unreleased](#unreleased)
 - [2.x.x](#2xx)
   - [Version 2.1.2](#version-212)
   - [Version 2.1.1](#version-211)
@@ -16,11 +17,16 @@
 
 <!-- /TOC -->
 
+# Unreleased
+
+* N/A
+
 # 2.x.x
 
 ## Version 2.1.2
 
 * Fixed a problem where `ciso8601.__version__` was not working (#80). Thanks @ianhoffman.
+* Added Python 3.8 support
 
 ## Version 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@
 ## Version 2.1.2
 
 * Fixed a problem where `ciso8601.__version__` was not working (#80). Thanks @ianhoffman.
-* Added Python 3.8 support
+* Added Python 3.8 support (#83)
+* Added benchmarking scripts (#55)
 
 ## Version 2.1.1
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7.
+Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8.
 
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,12 @@ ciso8601
 Since it's written as a C module, it is much faster than other Python libraries.
 Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8.
 
+**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
+
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339
+
+.. _`only a popular subset`: https://github.com/closeio/ciso8601#supported-subset-of-iso-8601
 
 (Interested in working on projects like this? `Close`_ is looking for `great engineers`_ to join our team)
 
@@ -68,77 +72,118 @@ If time zone information is provided, an aware datetime object will be returned.
 Benchmark
 ---------
 
-Date time string with no time zone information:
+Parsing a timestamp with no time zone information (ex. ``2014-01-09T21:48:00``):
+
+.. <include:benchmark_with_no_time_zone.rst>
+
+.. table:: 
+
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |    Module     |Python 3.8|Python 3.7|Python 3.6|Python 3.5|Python 3.4|          Python 2.7           |Relative Slowdown (versus ciso8601, Python 3.8)|
+    +===============+==========+==========+==========+==========+==========+===============================+===============================================+
+    |ciso8601       |201 nsec  |157 nsec  |160 nsec  |139 nsec  |148 nsec  |147 nsec                       |N/A                                            |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |pendulum       |215 nsec  |232 nsec  |234 nsec  |205 nsec  |192 nsec  |9.44 usec                      |1.1x                                           |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |udatetime      |906 nsec  |1.06 usec |767 nsec  |702 nsec  |819 nsec  |923 nsec                       |4.5x                                           |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |str2date       |5.96 usec |7.75 usec |7.27 usec |6.84 usec |7.6 usec  |**Incorrect Result** (``None``)|29.7x                                          |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |isodate        |10.3 usec |10 usec   |11.1 usec |11.9 usec |12.3 usec |43.6 usec                      |51.3x                                          |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |iso8601utils   |10.3 usec |8.63 usec |9.16 usec |10.3 usec |9.58 usec |11.1 usec                      |51.5x                                          |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |iso8601        |10.9 usec |11.1 usec |10.5 usec |11.2 usec |11.5 usec |25.6 usec                      |54.2x                                          |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |PySO8601       |13.9 usec |21.9 usec |20.2 usec |15.9 usec |23.7 usec |16.4 usec                      |69.4x                                          |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |aniso8601      |14.5 usec |15 usec   |15.8 usec |15.9 usec |16.1 usec |17.2 usec                      |72.5x                                          |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |zulu           |25.3 usec |29.9 usec |28.2 usec |27.4 usec |33 usec   |N/A                            |126.3x                                         |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |maya           |42.9 usec |57.4 usec |58.2 usec |67.5 usec |87.6 usec |100 usec                       |213.7x                                         |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |arrow          |85.7 usec |81.8 usec |75.7 usec |78.7 usec |N/A       |93.9 usec                      |427.1x                                         |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |python-dateutil|122 usec  |82.7 usec |72.2 usec |77.1 usec |74.4 usec |131 usec                       |609.5x                                         |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+    |moment         |3.81 msec |4.46 msec |3.12 msec |3.66 msec |N/A       |3.59 msec                      |19011.9x                                       |
+    +---------------+----------+----------+----------+----------+----------+-------------------------------+-----------------------------------------------+
+
+ciso8601 takes 201 nsec, which is **1.1x faster than pendulum**, the next fastest ISO 8601 parser in this comparison.
+
+.. </include:benchmark_with_no_time_zone.rst>
+
+Parsing a timestamp with time zone information (ex. ``2014-01-09T21:48:00-05:30``):
+
+.. <include:benchmark_with_time_zone.rst>
+
+.. table:: 
+
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |    Module     |          Python 3.8           |          Python 3.7           |          Python 3.6           |          Python 3.5           |Python 3.4|          Python 2.7           |Relative Slowdown (versus ciso8601, Python 3.8)|
+    +===============+===============================+===============================+===============================+===============================+==========+===============================+===============================================+
+    |ciso8601       |207 nsec                       |219 nsec                       |282 nsec                       |262 nsec                       |264 nsec  |360 nsec                       |N/A                                            |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |pendulum       |249 nsec                       |225 nsec                       |209 nsec                       |212 nsec                       |209 nsec  |12.9 usec                      |1.2x                                           |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |udatetime      |806 nsec                       |866 nsec                       |817 nsec                       |827 nsec                       |792 nsec  |835 nsec                       |3.9x                                           |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |str2date       |7.57 usec                      |10.7 usec                      |7.98 usec                      |8.48 usec                      |9.06 usec |**Incorrect Result** (``None``)|36.7x                                          |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |isodate        |12 usec                        |13.5 usec                      |14.7 usec                      |15.4 usec                      |18.8 usec |47.6 usec                      |58.3x                                          |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |iso8601        |12.8 usec                      |14.6 usec                      |14.6 usec                      |15.2 usec                      |17.7 usec |30 usec                        |61.8x                                          |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |aniso8601      |19.4 usec                      |30.4 usec                      |22.1 usec                      |20.5 usec                      |21.9 usec |20.1 usec                      |94.0x                                          |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |iso8601utils   |22.5 usec                      |25.3 usec                      |26.4 usec                      |25.7 usec                      |27 usec   |26.9 usec                      |108.9x                                         |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |zulu           |25.6 usec                      |31.2 usec                      |30 usec                        |32.3 usec                      |30.7 usec |N/A                            |124.1x                                         |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |PySO8601       |25.9 usec                      |35.4 usec                      |25.6 usec                      |29.5 usec                      |27.7 usec |25.7 usec                      |125.2x                                         |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |maya           |48.5 usec                      |46.6 usec                      |51.3 usec                      |63.2 usec                      |68.1 usec |125 usec                       |234.9x                                         |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |python-dateutil|79.3 usec                      |88.5 usec                      |101 usec                       |89.8 usec                      |91.9 usec |160 usec                       |384.2x                                         |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |arrow          |86.2 usec                      |95.2 usec                      |95 usec                        |101 usec                       |N/A       |103 usec                       |417.2x                                         |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+    |moment         |**Incorrect Result** (``None``)|**Incorrect Result** (``None``)|**Incorrect Result** (``None``)|**Incorrect Result** (``None``)|N/A       |**Incorrect Result** (``None``)|3442935.3x                                     |
+    +---------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+----------+-------------------------------+-----------------------------------------------+
+
+ciso8601 takes 207 nsec, which is **1.2x faster than pendulum**, the next fastest ISO 8601 parser in this comparison.
+
+.. </include:benchmark_with_time_zone.rst>
+
+.. <include:benchmark_module_versions.rst>
+
+Tested on Darwin 18.7.0 using the following modules:
 
 .. code:: python
 
-  In [1]: import datetime, aniso8601, iso8601, isodate, dateutil.parser, arrow, ciso8601
-
-  In [2]: ds = u'2014-01-09T21:48:00.921000'
-
-  In [3]: %timeit ciso8601.parse_datetime(ds)
-  1000000 loops, best of 3: 204 ns per loop
-
-  In [4]: %timeit datetime.datetime.strptime(ds, "%Y-%m-%dT%H:%M:%S.%f")
-  100000 loops, best of 3: 15 µs per loop
-
-  In [5]: %timeit dateutil.parser.parse(ds)
-  10000 loops, best of 3: 122 µs per loop
-
-  In [6]: %timeit aniso8601.parse_datetime(ds)
-  10000 loops, best of 3: 28.9 µs per loop
-
-  In [7]: %timeit iso8601.parse_date(ds)
-  10000 loops, best of 3: 42 µs per loop
-
-  In [8]: %timeit isodate.parse_datetime(ds)
-  10000 loops, best of 3: 69.4 µs per loop
-
-  In [9]: %timeit arrow.get(ds).datetime
-  10000 loops, best of 3: 87 µs per loop
-
-ciso8601 takes 0.204us, which is 73x faster than datetime's strptime, which is
-not a full ISO8601 parser. It is **141x faster than aniso8601**, the next fastest
-ISO8601 parser in this comparison.
-
-Date time string with time zone information:
-
-.. code:: python
-
-  In [1]: import datetime, aniso8601, iso8601, isodate, dateutil.parser, arrow, ciso8601
-
-  In [2]: ds = u'2014-01-09T21:48:00.921000+05:30'
-
-  In [3]: %timeit ciso8601.parse_datetime(ds)
-  1000000 loops, best of 3: 525 ns per loop
-
-  In [4]: %timeit dateutil.parser.parse(ds)
-  10000 loops, best of 3: 162 µs per loop
-
-  In [5]: %timeit aniso8601.parse_datetime(ds)
-  10000 loops, best of 3: 36.8 µs per loop
-
-  In [6]: %timeit iso8601.parse_date(ds)
-  10000 loops, best of 3: 53.5 µs per loop
-
-  In [7]: %timeit isodate.parse_datetime(ds)
-  10000 loops, best of 3: 82.6 µs per loop
-
-  In [8]: %timeit arrow.get(ds).datetime
-  10000 loops, best of 3: 104 µs per loop
-
-Even with time zone information, ``ciso8601`` is 70x as fast as ``aniso8601``.
-
-Tested on Python 2.7.10 on macOS 10.12.6 using the following modules:
-
-.. code:: python
-
-  aniso8601==1.2.1
-  arrow==0.10.0
-  ciso8601==1.0.4
+  aniso8601==8.0.0
+  arrow==0.15.2
+  ciso8601==2.1.2
   iso8601==0.1.12
-  isodate==0.5.4
-  python-dateutil==2.6.1
+  iso8601utils==0.1.2
+  isodate==0.6.0
+  maya==0.6.1
+  moment==0.8.2
+  pendulum==2.0.5
+  PySO8601==0.2.0
+  python-dateutil==2.8.0
+  str2date==0.905
+  udatetime==0.0.16
+  zulu==1.1.1
+
+.. </include:benchmark_module_versions.rst>
+
+**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
+
+For full benchmarking details (or to run the benchmark yourself), see `benchmarking/README.rst`_
+
+.. _`benchmarking/README.rst`: https://github.com/closeio/ciso8601/blob/master/benchmarking/README.rst
 
 Dependency on pytz (Python 2)
 -----------------------------
@@ -159,7 +204,7 @@ Otherwise, ``ciso8601`` will raise an exception when you try to parse a timestam
   Out[2]: ImportError: Cannot parse a timestamp with time zone information without the pytz dependency. Install it with `pip install pytz`.
 
 ``pytz`` is intentionally not an explicit dependency of ``ciso8601``. This is because many users use ``ciso8601`` to parse only naive timestamps, and therefore don't need this extra dependency.
-In Python 3, ``ciso8601`` makes use of the built-in `datetime.timezone`_ class instead, so pytz is not necessary.
+In Python 3, ``ciso8601`` makes use of the built-in `datetime.timezone`_ class instead, so ``pytz`` is not necessary.
 
 .. _datetime.timezone: https://docs.python.org/3/library/datetime.html#timezone-objects
 

--- a/benchmarking/README.rst
+++ b/benchmarking/README.rst
@@ -1,0 +1,88 @@
+=====================
+Benchmarking ciso8601
+=====================
+
+.. contents:: Contents
+
+Introduction
+------------
+
+``ciso8601``'s goal is to be the world's fastest ISO 8601 datetime parser for Python (**Note:** ciso8601 `only supports a subset of ISO 8601`_).
+
+.. _`only supports a subset of ISO 8601`: https://github.com/closeio/ciso8601#supported-subset-of-iso-8601
+
+In order to see how we compare, we run benchmarks against each other known ISO 8601 parser.
+
+**Note:** We only run benchmarks against open-source parsers that are published as part of Python modules on `PyPI`_.
+
+.. _`PyPI`: https://pypi.org/
+
+Quick start: Running the standard benchmarks
+--------------------------------------------
+
+If you just want to run the standard benchmarks we run for each release, there is a convenience script.
+
+.. code:: bash
+
+  % python -m venv env
+  % source env/bin/activate
+  % pip install -r requirements.txt
+  % ./run_benchmarks.sh
+
+This runs the benchmarks and generates reStructuredText files. The contents of these files are then automatically copy-pasted into ciso8601's `README.rst`_.
+
+.. _`README.rst`: https://github.com/closeio/ciso8601/blob/master/README.rst
+
+Running custom benchmarks
+-------------------------
+
+Running a custom benchmark is done by supplying `tox`_ with your custom timestamp: 
+
+.. code:: bash
+
+  % python -m venv env
+  % source env/bin/activate
+  % pip install -r requirements.txt
+  % tox '2014-01-09T21:48:00'
+
+It calls `perform_comparison.py`_ in each of the supported Python interpreters on your machine.
+This in turn calls `timeit`_ for each of the modules defined in ``ISO_8601_MODULES``. 
+
+.. _`tox`: https://tox.readthedocs.io/en/latest/index.html
+.. _`timeit`: https://docs.python.org/3/library/timeit.html
+
+Results are dumped into a collection of CSV files (in the ``benchmark_results`` directory by default).
+
+These CSV files can then formatted into reStructuredText tables by `format_results.py`_:
+
+.. _`perform_comparison.py`: https://github.com/closeio/ciso8601/blob/master/benchmarking/perform_comparison.py
+.. _`format_results.py`: https://github.com/closeio/ciso8601/blob/master/benchmarking/format_results.py
+
+.. code:: bash
+
+  % cd benchmarking
+  % python format_results.py benchmark_results/2014-01-09T214800 benchmark_results/benchmark_with_no_time_zone.rst
+  % python format_results.py benchmark_results/2014-01-09T214800-0530 benchmark_results/benchmark_with_time_zone.rst
+
+Disclaimer
+-----------
+
+Because of the way that ``tox`` works (and the way the benchmark is structured more generally), it doesn't make sense to compare the results for a given module across different Python versions.
+Comparisons between modules within the same Python version are still valid, and indeed, are the goal of the benchmarks.
+
+FAQs
+----
+
+"What about <missing module>?"
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We only run benchmarks against open-source parsers that are published as part of Python modules on PyPI.
+
+Do you know of a competing module missing from these benchmarks? We made it easy to add additional modules to our benchmarking:
+
+1. Add the dependency to ``tox.ini``
+1. Add the import statement and the parse statement for the module to ``ISO_8601_MODULES`` in `perform_comparison.py`_
+
+`Submit a pull request`_ and we'll probably add it to our official benchmarks.
+
+.. _`Submit a pull request`: https://github.com/closeio/ciso8601/blob/master/CONTRIBUTING.md

--- a/benchmarking/format_results.py
+++ b/benchmarking/format_results.py
@@ -1,0 +1,167 @@
+import argparse
+import csv
+import os
+import platform
+import pytablewriter
+import re
+import sys
+
+from collections import defaultdict, namedtuple
+
+Result = namedtuple('Result', ['timing', 'parsed_value', 'exception', 'matched_expected'])
+
+FILENAME_REGEX_RAW = r"benchmark_timings_python(\d)(\d).csv"
+FILENAME_REGEX = re.compile(FILENAME_REGEX_RAW)
+
+MODULE_VERSION_FILENAME_REGEX_RAW = r"module_versions_python(\d)(\d).csv"
+MODULE_VERSION_FILENAME_REGEX = re.compile(MODULE_VERSION_FILENAME_REGEX_RAW)
+
+UNITS = {"nsec": 1e-9, "usec": 1e-6, "msec": 1e-3, "sec": 1.0}
+SCALES = sorted([(scale, unit) for unit, scale in UNITS.items()], reverse=True)
+
+NOT_APPLICABLE = 'N/A'
+
+def format_duration(duration):
+    # Based on cPython's `timeit` CLI formatting
+    scale, unit = next(((scale, unit) for scale, unit in SCALES if duration >= scale), SCALES[-1])
+    precision = 3
+    return "%.*g %s" % (precision, duration / scale, unit)
+
+
+def format_relative(d1, d2):
+    if d1 is None or d2 is None:
+        return NOT_APPLICABLE
+    precision = 1
+    return "%.*fx" % (precision, d1 / d2)
+
+
+def determine_used_module_versions(results_directory):
+    module_versions_used = defaultdict(dict)
+    for parent, _dirs, files in os.walk(results_directory):
+        files_to_process = [f for f in files if MODULE_VERSION_FILENAME_REGEX.match(f)]
+        for csv_file in files_to_process:
+            with open(os.path.join(parent, csv_file), 'r') as fin:
+                reader = csv.reader(fin, delimiter=",", quotechar='"')
+                major, minor = next(reader)
+                for module, version in reader:
+                    if version not in module_versions_used[module]:
+                        module_versions_used[module][version] = set()
+                    module_versions_used[module][version].add('.'.join((major, minor)))
+    return module_versions_used
+
+
+def format_used_module_versions(module_versions_used):
+    results = []
+    for module, versions in sorted(module_versions_used.items(), key=lambda x: x[0].lower()):
+        if len(versions) == 1:
+            results.append(f"{module}=={next(iter(versions.keys()))}")
+        else:
+            results.append(", ".join([f"{module}=={version} (on Python {', '.join(sorted(py_versions))})" for version, py_versions in versions.items()]))
+    return results
+
+
+def format_result(result):
+    if result == NOT_APPLICABLE:
+        return NOT_APPLICABLE
+    elif result.exception:
+        return f"Raised  ``{result.exception}`` Exception"
+    elif not result.matched_expected:
+        return f"**Incorrect Result** (``{result.parsed_value}``)"
+    else:
+        return format_duration(result.timing)
+
+
+def main(results_directory, output_file, compare_to, include_call, module_version_output):
+    calling_code = {}
+    timestamps = set()
+    all_results = defaultdict(dict)
+    timing_results = defaultdict(dict)
+
+    for parent, _dirs, files in os.walk(results_directory):
+        files_to_process = [f for f in files if FILENAME_REGEX.match(f)]
+        for csv_file in files_to_process:
+            try:
+                with open(os.path.join(parent, csv_file), 'r') as fin:
+                    reader = csv.reader(fin, delimiter=",", quotechar='"')
+                    major, minor, timestamp = next(reader)
+                    timestamps.add(timestamp)
+                    for module, _setup, stmt, parse_result, count, time_taken, matched, exception in reader:
+                        all_results[(major, minor)][module] = Result(float(time_taken) / int(count),
+                                                                    parse_result,
+                                                                    exception,
+                                                                    True if matched == "True" else False
+                                                                    )
+                        timing_results[(major, minor)][module] = all_results[(major, minor)][module].timing
+                        calling_code[module] = f"``{stmt.format(timestamp=timestamp)}``"
+            except:
+                print(f"Problem while parsing `{os.path.join(parent, csv_file)}`")
+                raise
+
+
+    if len(timestamps) > 1:
+        raise NotImplementedError(f"Found a mix of files in the results directory. Found files that represent the parsing of {timestamps}. Support for handling multiple timestamps is not implemented.")
+
+    all_modules = set([module for value in timing_results.values() for module in value.keys()])
+    python_versions_by_modernity = sorted(timing_results.keys(), reverse=True)
+    most_modern_python = python_versions_by_modernity[0]
+    modules_by_modern_speed = sorted(all_modules, key=lambda module: timing_results[most_modern_python][module])
+
+    writer = pytablewriter.RstGridTableWriter()
+    formatted_python_versions = ["Python {}".format(".".join(key)) for key in python_versions_by_modernity]
+    writer.header_list = ["Module"] + (["Call"] if include_call else []) + formatted_python_versions + [f"Relative Slowdown (versus {compare_to}, {formatted_python_versions[0]})"]
+    writer.type_hint_list = [pytablewriter.String] * len(writer.header_list)
+
+
+    calling_codes = [calling_code[module] for module in modules_by_modern_speed]
+    performance_results = [[format_result(all_results[python_version].get(module, NOT_APPLICABLE)) for python_version in python_versions_by_modernity] for module in modules_by_modern_speed]
+    relative_slowdowns = [format_relative(timing_results[most_modern_python].get(module), timing_results[most_modern_python].get(compare_to)) if module != compare_to else NOT_APPLICABLE for module in modules_by_modern_speed]
+    
+    writer.value_matrix = [
+        [module] + ([calling_code[module]] if include_call else []) + performance_by_version + [relative_slowdown] for module, calling_code, performance_by_version, relative_slowdown in zip(modules_by_modern_speed, calling_codes, performance_results, relative_slowdowns)
+    ]
+
+    with open(output_file, 'w') as fout:
+        writer.stream = fout
+        writer.write_table()
+        fout.write('\n')
+
+        if modules_by_modern_speed[0] == compare_to:
+            fout.write(f"{compare_to} takes {format_duration(timing_results[most_modern_python][compare_to])}, which is **{format_relative(timing_results[most_modern_python][modules_by_modern_speed[1]], timing_results[most_modern_python][compare_to])} faster than {modules_by_modern_speed[1]}**, the next fastest ISO 8601 parser in this comparison.\n")
+        else:
+            fout.write(f"{compare_to} takes {format_duration(timing_results[most_modern_python][compare_to])}, which is **{format_relative(timing_results[most_modern_python][compare_to], timing_results[most_modern_python][modules_by_modern_speed[0]])} slower than {modules_by_modern_speed[0]}**, the fastest ISO 8601 parser in this comparison.\n")
+
+    with open(os.path.join(os.path.dirname(output_file), module_version_output), 'w') as fout:
+        fout.write(f"Tested on {platform.system()} {platform.release()} using the following modules:\n")
+        fout.write('\n')
+        fout.write(".. code:: python\n")
+        fout.write('\n')
+        for module_version_line in format_used_module_versions(determine_used_module_versions(results_directory)):
+            fout.write(f"  {module_version_line}\n")
+
+
+if __name__ == '__main__':
+    OUTPUT_FILE_HELP = "The filepath to use when outputting the reStructuredText results."
+    RESULTS_DIR_HELP = f"Which directory the script should look in to find benchmarking results. Will process any file that match the regexes '{FILENAME_REGEX_RAW}' and '{MODULE_VERSION_FILENAME_REGEX_RAW}'."
+
+    BASE_LIBRARY_DEFAULT = "ciso8601"
+    BASE_LIBRARY_HELP = f"The module to make all relative calculations relative to (default: \"{BASE_LIBRARY_DEFAULT}\")."
+
+    INCLUDE_CALL_DEFAULT = False
+    INCLUDE_CALL_HELP = f"Whether or not to include a column showing the actual code call (default: {INCLUDE_CALL_DEFAULT})."
+
+    MODULE_VERSION_OUTPUT_FILE_DEFAULT = "benchmark_module_versions.rst"
+    MODULE_VERSION_OUTPUT_FILE_HELP = "The filename to use when outputting the reStructuredText list of module versions. Written to the same directory as `OUTPUT`"
+
+    parser = argparse.ArgumentParser("Formats the benchmarking results into a nicely formatted block of reStructuredText for use in the README.")
+    parser.add_argument("RESULTS", help=RESULTS_DIR_HELP)
+    parser.add_argument("OUTPUT", help=OUTPUT_FILE_HELP)
+    parser.add_argument("--base-module", required=False, default=BASE_LIBRARY_DEFAULT, help=BASE_LIBRARY_HELP)
+    parser.add_argument("--include-call", required=False, type=bool, default=INCLUDE_CALL_DEFAULT, help=INCLUDE_CALL_HELP)
+    parser.add_argument("--module-version-output", required=False, default=MODULE_VERSION_OUTPUT_FILE_DEFAULT, help=MODULE_VERSION_OUTPUT_FILE_HELP)
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.RESULTS):
+        raise ValueError(f'Results directory "{args.RESULTS}" does not exist.')
+
+    main(args.RESULTS, args.OUTPUT, args.base_module, args.include_call, args.module_version_output)

--- a/benchmarking/perform_comparison.py
+++ b/benchmarking/perform_comparison.py
@@ -1,0 +1,126 @@
+import argparse
+import csv
+import os
+import pytz
+import sys
+import timeit
+
+from datetime import datetime
+
+try:
+    from importlib.metadata import version as get_module_version
+except ImportError:
+    from importlib_metadata import version as get_module_version
+
+ISO_8601_MODULES = {
+    "aniso8601": ('import aniso8601', "aniso8601.parse_datetime('{timestamp}')"),
+    "ciso8601": ('import ciso8601', "ciso8601.parse_datetime('{timestamp}')"),
+    "python-dateutil": ('import dateutil.parser', "dateutil.parser.parse('{timestamp}')"),
+    "iso8601": ('import iso8601', "iso8601.parse_date('{timestamp}')"),
+    "iso8601utils": ('from iso8601utils import parsers', "parsers.datetime('{timestamp}')"),
+    "isodate": ('import isodate', "isodate.parse_datetime('{timestamp}')"),
+    "maya": ('import maya', "maya.parse('{timestamp}').datetime()"),
+    "pendulum": ('from pendulum.parsing import parse_iso8601', "parse_iso8601('{timestamp}')"),
+    "PySO8601": ('import PySO8601', "PySO8601.parse('{timestamp}')"),
+    "str2date": ('from str2date import str2date', "str2date('{timestamp}')"),
+}
+
+if os.name != 'nt':
+    # udatetime doesn't support Windows.
+    ISO_8601_MODULES["udatetime"] = ('import udatetime', "udatetime.from_string('{timestamp}')")
+
+if sys.version_info.major > 2:
+    # zulu no longer supports Python 2.7
+    ISO_8601_MODULES["zulu"] = ('import zulu', "zulu.parse('{timestamp}')")
+
+if (sys.version_info.major, sys.version_info.minor) != (3, 4):
+    # arrow no longer supports Python 3.4
+    ISO_8601_MODULES["arrow"] = ('import arrow', "arrow.get('{timestamp}').datetime")
+    # moment is built on `times`, which is built on `arrow`, which no longer supports Python 3.4
+    ISO_8601_MODULES["moment"] = ('import moment', "moment.date('{timestamp}').date")
+
+def check_roughly_equivalent(dt1, dt2):
+    # For the purposes of our benchmarking, we don't care if the datetime
+    # has tzinfo=UTC or is naive.
+    dt1 = dt1.replace(tzinfo=pytz.UTC) if isinstance(dt1, datetime) and dt1.tzinfo is None else dt1
+    dt2 = dt2.replace(tzinfo=pytz.UTC) if isinstance(dt2, datetime) and dt2.tzinfo is None else dt2
+    return dt1 == dt2
+
+
+def run_tests(timestamp, results_directory, compare_to):
+    # `Timer.autorange` only exists in Python 3.6+. We want the tests to run in a reasonable amount of time,
+    # but we don't want to have to hard-code how many times to run each test.
+    # So we make sure to call Python 3.6+ versions first. They output a file that the others use to know how many iterations to run.
+    test_interation_counts = {}
+    auto_range_file_obj = None
+    auto_range_file_writer = None
+    try:
+        if (sys.version_info.major == 3 and sys.version_info.minor >= 6) or sys.version_info.major > 3:
+            auto_range_file_obj = open(os.path.join(results_directory, "auto_range_counts.csv"), 'w')
+            auto_range_file_writer = csv.writer(auto_range_file_obj, delimiter=',', quotechar='"', lineterminator='\n')
+        else:
+            with open(os.path.join(results_directory, "auto_range_counts.csv"), "r") as fin:
+                reader = csv.reader(fin, delimiter=',', quotechar='"')
+                for module, count in reader:
+                    test_interation_counts[module] = int(count)
+
+        exec(ISO_8601_MODULES[compare_to][0])
+        expected_parse_result = eval(ISO_8601_MODULES[compare_to][1].format(timestamp=timestamp))
+
+        with open(os.path.join(results_directory, "benchmark_timings_python{major}{minor}.csv".format(major=sys.version_info.major, minor=sys.version_info.minor)), 'w') as fout:
+            writer = csv.writer(fout, delimiter=',', quotechar='"', lineterminator='\n')
+            writer.writerow([sys.version_info.major, sys.version_info.minor, timestamp])
+            for module, (setup, stmt) in ISO_8601_MODULES.items():
+                count = None
+                time_taken = None
+                exception = None
+                try:
+                    exec(setup)
+                    parse_result = eval(stmt.format(timestamp=timestamp))
+
+                    if module in test_interation_counts:
+                        count = test_interation_counts[module]
+                        timer = timeit.Timer(stmt=stmt.format(timestamp=timestamp), setup=setup)
+                        time_taken = timer.timeit(number=count)
+                    else:
+                        timer = timeit.Timer(stmt=stmt.format(timestamp=timestamp), setup=setup)
+                        count, time_taken = timer.autorange()
+                except Exception as exc:
+                    parse_result = None
+                    exception = type(exc)
+
+                writer.writerow([module, setup, stmt.format(timestamp=timestamp), parse_result if parse_result is not None else "None", count, time_taken, check_roughly_equivalent(parse_result, expected_parse_result), exception])
+
+                if auto_range_file_writer is not None:
+                    auto_range_file_writer.writerow([module, count])
+    finally:
+        if auto_range_file_obj is not None:
+            auto_range_file_obj.close()
+
+    with open(os.path.join(results_directory, "module_versions_python{major}{minor}.csv".format(major=sys.version_info.major, minor=sys.version_info.minor)), 'w') as fout:
+        module_version_writer = csv.writer(fout, delimiter=',', quotechar='"', lineterminator='\n')
+        module_version_writer.writerow([sys.version_info.major, sys.version_info.minor])
+        for module, (setup, stmt) in sorted(ISO_8601_MODULES.items(), key=lambda x: x[0].lower()):
+            module_version_writer.writerow([module, get_module_version(module)])
+
+
+if __name__ == '__main__':
+    TIMESTAMP_HELP = "Which ISO 8601 timestamp to parse"
+
+    BASE_LIBRARY_DEFAULT = "ciso8601"
+    BASE_LIBRARY_HELP = "The module to make correctness decisions relative to (default: \"{default}\").".format(default=BASE_LIBRARY_DEFAULT)
+
+    RESULTS_DIR_DEFAULT = "benchmark_results"
+    RESULTS_DIR_HELP = "Which directory the script should output benchmarking results. (default: \"{0}\")".format(RESULTS_DIR_DEFAULT)
+
+    parser = argparse.ArgumentParser("Runs `timeit` to benchmark a variety of ISO 8601 parsers.")
+    parser.add_argument("TIMESTAMP", help=TIMESTAMP_HELP)
+    parser.add_argument("--base-module", required=False, default=BASE_LIBRARY_DEFAULT, help=BASE_LIBRARY_HELP)
+    parser.add_argument("--results", required=False, default=RESULTS_DIR_DEFAULT, help=RESULTS_DIR_HELP)
+    args = parser.parse_args()
+
+    output_dir = os.path.join(args.results, args.TIMESTAMP.replace(":", ""))
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    run_tests(args.TIMESTAMP, output_dir, args.base_module)

--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -1,0 +1,3 @@
+importlib_metadata; python_version < '3.8'
+pytablewriter
+tox

--- a/benchmarking/rst_include_replace.py
+++ b/benchmarking/rst_include_replace.py
@@ -1,0 +1,65 @@
+import argparse
+import os
+import re
+
+# Since GitHub doesn't support the use of the reStructuredText `include` directive,
+# we must copy-paste the results into README.rst. To do this automatically, we came
+# up with a special comment syntax. This script will replace everything between the
+# two special comments with the content requested.
+# For example:
+#
+# .. <include:benchmark_module_versions.rst>
+# This content will be replaced by the content of "benchmark_module_versions.rst"
+# .. </include:benchmark_module_versions.rst>
+#
+INCLUDE_BLOCK_START = ".. <include:{filename}>"
+INCLUDE_BLOCK_END = ".. </include:{filename}>"
+
+
+def replace_include(target_filepath, include_file, source_filepath):
+    start_block_regex = re.compile(INCLUDE_BLOCK_START.format(filename=include_file))
+    end_block_regex = re.compile(INCLUDE_BLOCK_END.format(filename=include_file))
+
+    with open(source_filepath, 'r') as fin:
+        replacement_lines = iter(fin.readlines())
+
+    with open(target_filepath, 'r') as fin:
+        target_lines = iter(fin.readlines())
+    with open(target_filepath, 'w') as fout:
+        for line in target_lines:
+            if start_block_regex.match(line):
+                fout.write(line)
+                fout.write("\n")  # rST requires a blank line after comment lines
+                for replacement_line in replacement_lines:
+                    fout.write(replacement_line)
+                next_line = next(target_lines)
+                while not end_block_regex.match(next_line):
+                    try:
+                        next_line = next(target_lines)
+                    except StopIteration:
+                        break
+                fout.write("\n")  # rST requires a blank line before comment lines
+                fout.write(next_line)
+            else:
+                fout.write(line)
+
+
+if __name__ == '__main__':
+    TARGET_HELP = "The filepath you wish to replace tags within."
+    INCLUDE_TAG_HELP = "The filename within the tag you are hoping to replace. (ex. 'benchmark_with_time_zone.rst')"
+    SOURCE_HELP = "The filepath whose contents should be included into the TARGET file."
+
+    parser = argparse.ArgumentParser("Formats the benchmarking results into a nicely formatted block of reStructuredText for use in the README.")
+    parser.add_argument("TARGET", help=TARGET_HELP)
+    parser.add_argument("INCLUDE_TAG", help=INCLUDE_TAG_HELP)
+    parser.add_argument("SOURCE", help=SOURCE_HELP)
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.TARGET):
+        raise ValueError(f'TARGET path {args.TARGET} does not exist')
+
+    if not os.path.exists(args.SOURCE):
+        raise ValueError(f'SOURCE path {args.SOURCE} does not exist')
+
+    replace_include(args.TARGET, args.INCLUDE_TAG, args.SOURCE)

--- a/benchmarking/run_benchmarks.sh
+++ b/benchmarking/run_benchmarks.sh
@@ -1,0 +1,7 @@
+tox '2014-01-09T21:48:00'
+tox '2014-01-09T21:48:00-05:30'
+python format_results.py benchmark_results/2014-01-09T214800 benchmark_results/benchmark_with_no_time_zone.rst
+python format_results.py benchmark_results/2014-01-09T214800-0530 benchmark_results/benchmark_with_time_zone.rst
+python rst_include_replace.py ../README.rst 'benchmark_with_no_time_zone.rst' benchmark_results/benchmark_with_no_time_zone.rst
+python rst_include_replace.py ../README.rst 'benchmark_with_time_zone.rst' benchmark_results/benchmark_with_time_zone.rst
+python rst_include_replace.py ../README.rst 'benchmark_module_versions.rst' benchmark_results/benchmark_module_versions.rst

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = py38,py37,py36,py35,py34,py27
+setupdir=..
+
+[testenv]
+deps=
+    ; The libraries needed to run the benchmarking itself
+    -rrequirements.txt
+
+    ; The actual ISO 8601 parsing libraries
+    aniso8601
+    ; arrow no longer supports Python 3.4
+    arrow; python_version != '3.4'
+    iso8601
+    iso8601utils
+    isodate
+    maya
+    ; moment is built on `times`, which is built on `arrow`, which no longer supports Python 3.4 
+    moment; python_version != '3.4'
+    pendulum
+    pyso8601
+    python-dateutil
+    str2date
+    ; udatetime doesn't support Windows
+    udatetime; os_name != 'nt'
+    ; zulu no longer supports Python 2.7
+    zulu; python_version > '2.7'
+    pytz
+commands=
+    python -W ignore perform_comparison.py {posargs:DEFAULTS}

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if os.environ.get("STRICT_WARNINGS", '0') == '1':
         os.environ['_CL_'] = ""
     os.environ['_CL_'] += " /WX"
 
-VERSION = "2.1.1"
+VERSION = "2.1.2"
 
 setup(
     name="ciso8601",


### PR DESCRIPTION
In preparation for a version 2.1.2 release.

Releases the fix from #81, Python 3.8 support (#83), and the benchmarking scripts (#55)