### PR TITLE
Python 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - test-3.5
       - test-3.6
       - test-3.7
+      - test-3.8
       - lint-rst
 
 defaults: &defaults
@@ -42,7 +43,11 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:3.7
-    
+  test-3.8:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.8
+
   lint-rst:
     working_directory: ~/code
     steps:
@@ -59,4 +64,4 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-    - image: circleci/python:3.7
+    - image: circleci/python:3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Generated with "Markdown T​O​C" extension for Visual Studio Code -->
 <!-- TOC anchorMode:github.com -->
 
+- [Unreleased](#unreleased)
 - [2.x.x](#2xx)
   - [Version 2.1.2](#version-212)
   - [Version 2.1.1](#version-211)
@@ -16,11 +17,16 @@
 
 <!-- /TOC -->
 
+# Unreleased
+
+* N/A
+
 # 2.x.x
 
 ## Version 2.1.2
 
 * Fixed a problem where `ciso8601.__version__` was not working (#80). Thanks @ianhoffman.
+* Added Python 3.8 support
 
 ## Version 2.1.1
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7.
+Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8.
 
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )


### PR DESCRIPTION
Let's start testing against Python 3.8 in preparation for an official release.