### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
       - test-3.6
       - test-3.7
       - test-3.8
+      - test-3.9
       - lint-rst
 
 defaults: &defaults
@@ -47,6 +48,10 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:3.8
+  test-3.9:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.9
 
   lint-rst:
     working_directory: ~/code
@@ -64,4 +69,4 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-    - image: circleci/python:3.8
+    - image: circleci/python:3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@
     - [v1.x.x -> 2.0.0 Migration guide](#v1xx---200-migration-guide)
       - [ValueError instead of None](#valueerror-instead-of-none)
       - [Tightened ISO 8601 conformance](#tightened-iso-8601-conformance)
-      - [`parse_datetime_unaware` has been renamed](#parsedatetimeunaware-has-been-renamed)
+      - [`parse_datetime_unaware` has been renamed](#parse_datetime_unaware-has-been-renamed)
 
 <!-- /TOC -->
 
 # Unreleased
 
-* N/A
+* Added Python 3.9 support
 
 # 2.x.x
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8.
+Tested with Python 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9.
 
 **Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]
 )


### PR DESCRIPTION
Add Python 3.9 to CI tests.