### PR TITLE
Modernize CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,57 +16,57 @@ workflows:
 defaults: &defaults
   working_directory: ~/code
   environment:
-    STRICT_WARNINGS: '1'
+    STRICT_WARNINGS: "1"
   steps:
-  - checkout
-  - run:
-      name: Test
-      command: python setup.py test
+    - checkout
+    - run:
+        name: Test
+        command: python setup.py test
 
 jobs:
   test-2.7:
     <<: *defaults
     docker:
-    - image: circleci/python:2.7
+      - image: circleci/python:2.7
   test-3.4:
     <<: *defaults
     docker:
-    - image: circleci/python:3.4
+      - image: circleci/python:3.4
   test-3.5:
     <<: *defaults
     docker:
-    - image: circleci/python:3.5
+      - image: circleci/python:3.5
   test-3.6:
     <<: *defaults
     docker:
-    - image: circleci/python:3.6
+      - image: circleci/python:3.6
   test-3.7:
     <<: *defaults
     docker:
-    - image: circleci/python:3.7
+      - image: circleci/python:3.7
   test-3.8:
     <<: *defaults
     docker:
-    - image: circleci/python:3.8
+      - image: circleci/python:3.8
   test-3.9:
     <<: *defaults
     docker:
-    - image: circleci/python:3.9
+      - image: circleci/python:3.9
 
   lint-rst:
     working_directory: ~/code
     steps:
-    - checkout
-    - run:
-        name: Install lint tools
-        command: |
+      - checkout
+      - run:
+          name: Install lint tools
+          command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install Pygments restructuredtext-lint
-    - run:
-        name: Lint
-        command:  |
+      - run:
+          name: Lint
+          command: |
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-    - image: circleci/python:3.9
+      - image: circleci/python:3.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,57 +1,26 @@
-version: 2
+version: 2.1
 
 workflows:
-  version: 2
   workflow:
     jobs:
-      - test-2.7
-      - test-3.4
-      - test-3.5
-      - test-3.6
-      - test-3.7
-      - test-3.8
-      - test-3.9
+      - test:
+          matrix:
+            parameters:
+              python_version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
       - lint-rst
 
-defaults: &defaults
-  working_directory: ~/code
-  environment:
-    STRICT_WARNINGS: "1"
-  steps:
-    - checkout
-    - run:
-        name: Test
-        command: python setup.py test
-
 jobs:
-  test-2.7:
-    <<: *defaults
+  test:
+    parameters:
+      python_version:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: python setup.py test
     docker:
-      - image: circleci/python:2.7
-  test-3.4:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.4
-  test-3.5:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.5
-  test-3.6:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.6
-  test-3.7:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.7
-  test-3.8:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.8
-  test-3.9:
-    <<: *defaults
-    docker:
-      - image: circleci/python:3.9
+      - image: circleci/python:<<parameters.python_version>>
 
   lint-rst:
     working_directory: ~/code


### PR DESCRIPTION
 Use version 2.1 of CircleCI:

- Can no longer specify a version in workflows.
- Can no longer have numbers in job names
- Use a [matrix](https://circleci.com/docs/2.0/configuration-reference/#matrix-requires-version-21) instead of duplicating the job for each Python version