### PR TITLE
Cache the timezone objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
         * ~2.5x faster on Python 2.7, ~10% faster on Python 3.9
     * Thanks to [`pendulum`](https://github.com/sdispater/pendulum) and @sdispater for the code.
     * Python 2.7 users no longer need to install `pytz` dependency :smiley:
+* Added caching of tzinfo objects
+  * Parsing is ~1.1x faster for subsequent timestamps that have the same time zone offset.
+  * Caching can be disabled at compile time by setting the `CISO8601_CACHING_ENABLED=0` environment variable
 
 # 2.x.x
 

--- a/benchmarking/README.rst
+++ b/benchmarking/README.rst
@@ -80,6 +80,15 @@ Disclaimer
 Because of the way that ``tox`` works (and the way the benchmark is structured more generally), it doesn't make sense to compare the results for a given module across different Python versions.
 Comparisons between modules within the same Python version are still valid, and indeed, are the goal of the benchmarks.
 
+Caching
+-------
+
+`ciso8601` caches the ``tzinfo`` objects it creates, allowing it to reuse those objects for faster creation of subsequent ``datetime`` objects.
+For example, for some types of profiling, it makes sense not to have a cache.
+Caching can be disabled by modifying the `tox.ini`_ and changing ``CISO8601_CACHING_ENABLED`` to ``0``.
+
+.. _`tox.ini`: https://github.com/closeio/ciso8601/blob/master/benchmarking/tox.ini
+
 FAQs
 ----
 

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -3,6 +3,8 @@ envlist = py39,py38,py37,py36,py35,py34,py27
 setupdir=..
 
 [testenv]
+setenv =
+    CISO8601_CACHING_ENABLED = 1
 deps=
     ; The libraries needed to run the benchmarking itself
     -rrequirements.txt

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if os.environ.get("STRICT_WARNINGS", "0") == "1":
     os.environ["_CL_"] += " /WX"
 
 VERSION = "2.1.3"
+CISO8601_CACHING_ENABLED = int(os.environ.get('CISO8601_CACHING_ENABLED', '1') == '1')
 
 setup(
     name="ciso8601",
@@ -44,7 +45,10 @@ setup(
         Extension(
             "ciso8601",
             sources=["module.c", "timezone.c"],
-            define_macros=[("CISO8601_VERSION", VERSION)],
+            define_macros=[
+                ("CISO8601_VERSION", VERSION),
+                ("CISO8601_CACHING_ENABLED", CISO8601_CACHING_ENABLED),
+            ],
         )
     ],
     packages=["ciso8601"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = {py27,py34,py35,py36,py37,py38,py39}-caching_{enabled,disabled}
 
 [testenv]
-setenv=
-    STRICT_WARNINGS=1
-deps=
+setenv =
+    STRICT_WARNINGS = 1
+    caching_enabled: CISO8601_CACHING_ENABLED = 1
+    caching_disabled: CISO8601_CACHING_ENABLED = 0
+deps =
     pytz
     nose
     unittest2


### PR DESCRIPTION
Processing multiple timestamps can be faster, since they just use the cached timezone object instead of recreating them each time.

Implements #47. This is a re-implementation of #48, on top of #58. As such, it should not be merged until after #58

### Disabling caching

We may want to disable caching in some cases. For example, for some types of profiling, it makes sense not to have a cache.
This caching can be disabled at compile time by setting the `CISO8601_CACHING_ENABLED=0` environment variable.

### Memory usage

There are 2879 possible valid timezone offsets in Python (-1439, 1439). If you had some very strange dataset, you could end up caching all of them. This would consume approximately 100 KB of RAM. I consider this to be an acceptable amount of RAM (and this would be a very odd scenario), so I haven't implemented the complexity of an LRU cache.

### Performance boost

Approximate numbers, just take from running the benchmark scripts (which reuse the same offsets) once on each branch.

| Python version | ciso8601 2.1.3 | PR #58   | This PR  | Relative Speedup (over PR #58) |
| -------------- | -------------- | -------- | -------- | ------------------------------ |
| Python 3.9     | 207 nsec       | 185 nsec | 157 nsec | 1.18x                          |
| Python 3.8     | 228 nsec       | 185 nsec | 164 nsec | 1.12x                          |
| Python 3.7     | 291 nsec       | 253 nsec | 218 nsec | 1.16x                          |
| Python 3.6     | 432 nsec       | 245 nsec | 210 nsec | 1.17x                          |
| Python 3.5     | 374 nsec       | 205 nsec | 192 nsec | 1.07x                          |
| Python 2.7     | 537 nsec       | 202 nsec | 170 nsec | 1.19x                          |