### PR TITLE
Build wheels for variety of platforms using cibuildwheel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,69 @@
+name: Build Wheels
+
+# Only run on new tags starting with `v`
+on:
+  push:
+    # tags:
+    #   - 'v*'
+
+jobs:
+  build_wheels:
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.1.1
+      env:
+        # From rio-color here:
+        # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3
+        # Skip Python 3.10 until officially released, as numpy wheels aren't yet
+        # available
+        CIBW_SKIP: "cp2* cp35* cp310* pp* *-win32 *-manylinux_i686"
+        CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+        CIBW_BEFORE_BUILD: python -m pip install numpy Cython
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install build dependencies
+        run: python -m pip install '.[build]'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  # upload_pypi:
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v2
+  #       with:
+  #         name: artifact
+  #         path: dist
+  #
+  #     - uses: pypa/gh-action-pypi-publish@master
+  #       with:
+  #         user: __token__
+  #         password: ${{ secrets.PYPI_PASSWORD }}
+  #         # To test: repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -24,7 +24,7 @@ jobs:
         # https://github.com/mapbox/rio-color/blob/0ab59ad8e2db99ad1d0c8bd8c2e4cf8d0c3114cf/appveyor.yml#L3
         # Skip Python 3.10 until officially released, as numpy wheels aren't yet
         # available
-        CIBW_SKIP: "cp2* cp35* cp310* pp* *-win32 *-manylinux_i686"
+        CIBW_SKIP: "cp310* *-win32 *-manylinux_i686"
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         CIBW_BEFORE_BUILD: python -m pip install numpy Cython
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,7 +26,6 @@ jobs:
         # available
         CIBW_SKIP: "cp310* *-win32 *-manylinux_i686"
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-        CIBW_BEFORE_BUILD: python -m pip install numpy Cython
 
     - uses: actions/upload-artifact@v2
       with:
@@ -42,9 +41,6 @@ jobs:
         name: Install Python
         with:
           python-version: '3.8'
-
-      - name: Install build dependencies
-        run: python -m pip install '.[build]'
 
       - name: Build sdist
         run: python setup.py sdist


### PR DESCRIPTION
I just came across this project and saw #25. I've set up building wheels on CI for a variety of projects so figured I'd send over a quick PR. This PR provides a working demo of using [`cibuildwheel`](https://github.com/pypa/cibuildwheel) to build wheels on CI for a matrix of Python 3.6 through 3.9, PyPy, CPython, Windows, Linux, Mac, and Mac ARM.

Example output from [Github Actions run:](https://github.com/kylebarron/ciso8601/runs/3304301552) [artifact.zip](https://github.com/closeio/ciso8601/files/6970756/artifact.zip) (you can only download output if it's your own repo I think)

Contains these files:
```
ciso8601-2.2.0-cp36-cp36m-macosx_10_9_x86_64.whl
ciso8601-2.2.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
ciso8601-2.2.0-cp36-cp36m-win_amd64.whl
ciso8601-2.2.0-cp37-cp37m-macosx_10_9_x86_64.whl
ciso8601-2.2.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
ciso8601-2.2.0-cp37-cp37m-win_amd64.whl
ciso8601-2.2.0-cp38-cp38-macosx_10_9_universal2.whl
ciso8601-2.2.0-cp38-cp38-macosx_10_9_x86_64.whl
ciso8601-2.2.0-cp38-cp38-macosx_11_0_arm64.whl
ciso8601-2.2.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
ciso8601-2.2.0-cp38-cp38-win_amd64.whl
ciso8601-2.2.0-cp39-cp39-macosx_10_9_universal2.whl
ciso8601-2.2.0-cp39-cp39-macosx_10_9_x86_64.whl
ciso8601-2.2.0-cp39-cp39-macosx_11_0_arm64.whl
ciso8601-2.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
ciso8601-2.2.0-cp39-cp39-win_amd64.whl
ciso8601-2.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl
ciso8601-2.2.0-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
ciso8601-2.2.0-pp37-pypy37_pp73-win_amd64.whl
ciso8601-2.2.0.tar.gz
```

### Notes:

- [`cibuildwheel`](https://github.com/pypa/cibuildwheel) was somewhat recently added to the [`pypa`](https://github.com/pypa) organization, so it's likely to be well maintained into the future.
- cibuildwheel v2 doesn't support deprecated Python versions such as Python 2.7 or 3.5. So the wheels built are for Python 3.6+.
- I see you currently use CircleCI. cibuildwheel [supports](https://cibuildwheel.readthedocs.io/en/stable/#usage) CircleCI, but only on Linux and MacOS, and doesn't support Windows. I've used Github Actions more, so it was both faster to provide a demo using that and it also shows that you can build Mac, Windows, and Linux wheels with it.