### PR TITLE
Add Python 3.10 to tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python_version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9"]
+              python_version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
       - test_pypy:
           matrix:
             parameters:
@@ -54,4 +54,4 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-      - image: circleci/python:3.9
+      - image: circleci/python:3.10

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9.
+Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.
 
 **Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
 

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -11,13 +11,14 @@ RUN apt install -y python python-dev && \
     apt install -y python3.6 python3.6-dev python3.6-venv && \
     apt install -y python3.7 python3.7-dev python3.7-venv && \
     apt install -y python3.8 python3.8-dev python3.8-venv && \
-    apt install -y python3.9 python3.9-dev python3.9-venv
+    apt install -y python3.9 python3.9-dev python3.9-venv && \
+    apt install -y python3.10 python3.10-dev python3.10-venv
 
 # Install the other dependencies
 RUN apt-get install -y git curl gcc build-essential
 
-# Make Python 3.9 the default `python`
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10
+# Make Python 3.10 the default `python`
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10
 
 # Get pip
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )


### PR DESCRIPTION
[Python 3.10 has been released.](https://docs.python.org/3.10/whatsnew/3.10.html)

Make sure that we're testing against it.