### PR TITLE
Implement `fromutc` for `FixedOffset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fix the build for PyPy2 ([#116](https://github.com/closeio/ciso8601/pull/116))
 * Added missing `fromutc` implementation for `FixedOffset` (#113). Thanks @davidkraljic
 * Removed improper ability to call `FixedOffset`'s `dst`, `tzname` and `utcoffset` without arguments
+* Fixed: `datetime.tzname` returns a `str` in Python 2.7, not a `unicode`
 
 # 2.x.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * Fix the build for PyPy2 ([#116](https://github.com/closeio/ciso8601/pull/116))
 * Added missing `fromutc` implementation for `FixedOffset` (#113). Thanks @davidkraljic
+* Removed improper ability to call `FixedOffset`'s `dst`, `tzname` and `utcoffset` without arguments
 
 # 2.x.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 # Unreleased
 
 * Fix the build for PyPy2 ([#116](https://github.com/closeio/ciso8601/pull/116))
+* Added missing `fromutc` implementation for `FixedOffset` (#113). Thanks @davidkraljic
 
 # 2.x.x
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -25,12 +25,13 @@ class TimezoneTestCase(unittest.TestCase):
                 built_in_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=tz)
                 our_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=FixedOffset(minutes * 60))
                 self.assertEqual(built_in_dt.utcoffset(), our_dt.utcoffset(), "`utcoffset` output did not match for offset: {minutes}".format(minutes=minutes))
+                self.assertEqual(built_in_dt.tzinfo.utcoffset(built_in_dt), our_dt.tzinfo.utcoffset(our_dt), "`tzinfo.utcoffset` output did not match for offset: {minutes}".format(minutes=minutes))
         else:
-            self.assertEqual(FixedOffset(0).utcoffset(), timedelta(minutes=0))
-            self.assertEqual(FixedOffset(+0).utcoffset(), timedelta(minutes=0))
-            self.assertEqual(FixedOffset(-0).utcoffset(), timedelta(minutes=0))
-            self.assertEqual(FixedOffset(-4980).utcoffset(), timedelta(hours=-1, minutes=-23))
-            self.assertEqual(FixedOffset(+45240).utcoffset(), timedelta(hours=12, minutes=34))
+            for seconds in [0, +0, -0, -4980, +45240]:
+                offset = FixedOffset(seconds)
+                our_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=offset)
+                self.assertEqual(our_dt.utcoffset(), timedelta(seconds=seconds))
+                self.assertEqual(offset.utcoffset(our_dt), timedelta(seconds=seconds))
 
     def test_dst(self):
         if sys.version_info >= (3, 2):
@@ -41,12 +42,13 @@ class TimezoneTestCase(unittest.TestCase):
                 built_in_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=tz)
                 our_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=FixedOffset(minutes * 60))
                 self.assertEqual(built_in_dt.dst(), our_dt.dst(), "`dst` output did not match for offset: {minutes}".format(minutes=minutes))
+                self.assertEqual(built_in_dt.tzinfo.dst(built_in_dt), our_dt.tzinfo.dst(our_dt), "`tzinfo.dst` output did not match for offset: {minutes}".format(minutes=minutes))
         else:
-            self.assertIsNone(FixedOffset(0).dst(), "UTC")
-            self.assertIsNone(FixedOffset(+0).dst(), "UTC")
-            self.assertIsNone(FixedOffset(-0).dst(), "UTC")
-            self.assertIsNone(FixedOffset(-4980).dst(), "UTC-01:23")
-            self.assertIsNone(FixedOffset(+45240).dst(), "UTC+12:34")
+            for seconds in [0, +0, -0, -4980, +45240]:
+                offset = FixedOffset(seconds)
+                our_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=offset)
+                self.assertIsNone(our_dt.dst())
+                self.assertIsNone(offset.dst(our_dt))
 
     def test_tzname(self):
         if sys.version_info >= (3, 2):
@@ -57,12 +59,13 @@ class TimezoneTestCase(unittest.TestCase):
                 built_in_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=tz)
                 our_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=FixedOffset(minutes * 60))
                 self.assertEqual(built_in_dt.tzname(), our_dt.tzname(), "`tzname` output did not match for offset: {minutes}".format(minutes=minutes))
+                self.assertEqual(built_in_dt.tzinfo.tzname(built_in_dt), our_dt.tzinfo.tzname(our_dt), "`tzinfo.tzname` output did not match for offset: {minutes}".format(minutes=minutes))
         else:
-            self.assertEqual(FixedOffset(0).tzname(), "UTC+00:00")
-            self.assertEqual(FixedOffset(+0).tzname(), "UTC+00:00")
-            self.assertEqual(FixedOffset(-0).tzname(), "UTC+00:00")
-            self.assertEqual(FixedOffset(-4980).tzname(), "UTC-01:23")
-            self.assertEqual(FixedOffset(+45240).tzname(), "UTC+12:34")
+            for seconds, expected_tzname in [(0, "UTC+00:00"), (+0, "UTC+00:00"), (-0, "UTC+00:00"), (-4980, "UTC-01:23"), (+45240, "UTC+12:34")]:
+                offset = FixedOffset(seconds)
+                our_dt = datetime(2014, 2, 3, 10, 35, 27, 234567, tzinfo=offset)
+                self.assertEqual(our_dt.tzname(), expected_tzname)
+                self.assertEqual(offset.tzname(our_dt), expected_tzname)
 
     def test_fromutc(self):
         # https://github.com/closeio/ciso8601/issues/108

--- a/timezone.c
+++ b/timezone.c
@@ -92,6 +92,25 @@ FixedOffset_dst(FixedOffset *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
+static PyObject *
+FixedOffset_fromutc(FixedOffset *self, PyDateTime_DateTime *dt)
+{
+    if (!PyDateTime_Check(dt)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "fromutc: argument must be a datetime");
+        return NULL;
+    }
+    if (!dt->hastzinfo || dt->tzinfo != (PyObject *)self) {
+        PyErr_SetString(PyExc_ValueError,
+                        "fromutc: dt.tzinfo "
+                        "is not self");
+        return NULL;
+    }
+
+    return PyNumber_Add((PyObject *)dt,
+                        FixedOffset_utcoffset(self, (PyObject *)self));
+}
+
 /*
  * def tzname(self, dt):
  *     sign = '+'
@@ -157,11 +176,20 @@ static PyMemberDef FixedOffset_members[] = {
  * Class methods
  */
 static PyMethodDef FixedOffset_methods[] = {
-    {"utcoffset", (PyCFunction)FixedOffset_utcoffset, METH_VARARGS, ""},
-    {"dst", (PyCFunction)FixedOffset_dst, METH_VARARGS, ""},
-    {"tzname", (PyCFunction)FixedOffset_tzname, METH_VARARGS, ""},
-    {"__getinitargs__", (PyCFunction)FixedOffset_getinitargs, METH_VARARGS,
-     ""},
+    {"utcoffset", (PyCFunction)FixedOffset_utcoffset, METH_O,
+     PyDoc_STR("Return fixed offset.")},
+
+    {"dst", (PyCFunction)FixedOffset_dst, METH_O, PyDoc_STR("Return None.")},
+
+    {"fromutc", (PyCFunction)FixedOffset_fromutc, METH_O,
+     PyDoc_STR("datetime in UTC -> datetime in local time.")},
+
+    {"tzname", (PyCFunction)FixedOffset_tzname, METH_O,
+     PyDoc_STR("Returns offset as 'UTC(+|-)HH:MM'")},
+
+    {"__getinitargs__", (PyCFunction)FixedOffset_getinitargs, METH_NOARGS,
+     PyDoc_STR("pickle support")},
+
     {NULL}};
 
 static PyTypeObject FixedOffset_type = {

--- a/timezone.c
+++ b/timezone.c
@@ -50,10 +50,6 @@ typedef struct {
     PyObject_HEAD int offset;
 } FixedOffset;
 
-/*
- * def __init__(self, offset):
- *     self.offset = offset
- */
 static int
 FixedOffset_init(FixedOffset *self, PyObject *args, PyObject *kwargs)
 {
@@ -72,22 +68,14 @@ FixedOffset_init(FixedOffset *self, PyObject *args, PyObject *kwargs)
     return 0;
 }
 
-/*
- * def utcoffset(self, dt):
- *     return timedelta(seconds=self.offset * 60)
- */
 static PyObject *
-FixedOffset_utcoffset(FixedOffset *self, PyObject *args)
+FixedOffset_utcoffset(FixedOffset *self, PyObject *dt)
 {
     return PyDelta_FromDSU(0, self->offset, 0);
 }
 
-/*
- * def dst(self, dt):
- *     return timedelta(seconds=self.offset * 60)
- */
 static PyObject *
-FixedOffset_dst(FixedOffset *self, PyObject *args)
+FixedOffset_dst(FixedOffset *self, PyObject *dt)
 {
     Py_RETURN_NONE;
 }
@@ -111,26 +99,19 @@ FixedOffset_fromutc(FixedOffset *self, PyDateTime_DateTime *dt)
                         FixedOffset_utcoffset(self, (PyObject *)self));
 }
 
-/*
- * def tzname(self, dt):
- *     sign = '+'
- *     if self.offset < 0:
- *         sign = '-'
- *     return "%s%d:%d" % (sign, self.offset / 60, self.offset % 60)
- */
 static PyObject *
-FixedOffset_tzname(FixedOffset *self, PyObject *args)
+FixedOffset_tzname(FixedOffset *self, PyObject *dt)
 {
-
     int offset = self->offset;
 
-    if (offset == 0){
+    if (offset == 0) {
 #if PY_VERSION_AT_LEAST_36
         return PyUnicode_FromString("UTC");
 #else
         return PyUnicode_FromString("UTC+00:00");
 #endif
-    } else {
+    }
+    else {
         char result_tzname[10] = {0};
         char sign = '+';
 
@@ -139,26 +120,18 @@ FixedOffset_tzname(FixedOffset *self, PyObject *args)
             offset *= -1;
         }
         snprintf(result_tzname, 10, "UTC%c%02u:%02u", sign,
-             (offset / SECS_PER_HOUR) & 31,
-             offset / SECS_PER_MIN % SECS_PER_MIN);
+                 (offset / SECS_PER_HOUR) & 31,
+                 offset / SECS_PER_MIN % SECS_PER_MIN);
         return PyUnicode_FromString(result_tzname);
     }
 }
 
-/*
- * def __repr__(self):
- *     return self.tzname()
- */
 static PyObject *
 FixedOffset_repr(FixedOffset *self)
 {
     return FixedOffset_tzname(self, NULL);
 }
 
-/*
- * def __getinitargs__(self):
- *     return (self.offset,)
- */
 static PyObject *
 FixedOffset_getinitargs(FixedOffset *self)
 {

--- a/timezone.c
+++ b/timezone.c
@@ -107,8 +107,10 @@ FixedOffset_tzname(FixedOffset *self, PyObject *dt)
     if (offset == 0) {
 #if PY_VERSION_AT_LEAST_36
         return PyUnicode_FromString("UTC");
-#else
+#elif PY_MAJOR_VERSION >= 3
         return PyUnicode_FromString("UTC+00:00");
+#else
+        return PyString_FromString("UTC+00:00");
 #endif
     }
     else {
@@ -122,7 +124,11 @@ FixedOffset_tzname(FixedOffset *self, PyObject *dt)
         snprintf(result_tzname, 10, "UTC%c%02u:%02u", sign,
                  (offset / SECS_PER_HOUR) & 31,
                  offset / SECS_PER_MIN % SECS_PER_MIN);
+#if PY_MAJOR_VERSION >= 3
         return PyUnicode_FromString(result_tzname);
+#else
+        return PyString_FromString(result_tzname);
+#endif
     }
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #108. cc @davidkraljic @deargle

### What approach did you choose and why?

[The docs](https://docs.python.org/3/library/datetime.html#datetime.tzinfo.dst) are a little inconsistent when they describe what the behaviour of `dst` should be for fixed offset `tzinfo` objects:

> Return the daylight saving time (DST) adjustment, as a `timedelta` object or `None` if DST information isn’t known.

The way I think about fixed offset `tzinfo` objects, is that they don't know any DST information, so they should return `None`.
Indeed, that is [what the `timezone_dst` upstream code does](https://github.com/python/cpython/blob/8f943ca25732d548cf9f0b0393ba8d582fb93e29/Modules/_datetimemodule.c#L3985-L3992).

However, the docs continue to say...

> Most implementations of dst() will probably look like one of these two:

```python
def dst(self, dt):
    # a fixed-offset class:  doesn't account for DST
    return timedelta(0)
```

Which suggests that a fixed-offset implementation should return `timedelta(0)`.

Indeed, the default implementation of `fromutc` checks to ensure that `dst` does not return `None` (which is #108).
The `timezone` implementation avoids this by implementing its own `fromutc`.

---

So that covers the two options I had to fix this...

1. Change the return value of `FixedOffset.dst` to return `timedelta(0)`
2. Keep the return value as `None`, but implement a `fromutc` method

I chose the latter, since I want to maintain exact behaviour with `timezone`. It also matches my understanding of how fixed offset implementations should behave; returning `timedelta(0)` implies that it knows something about DST, which it does not.

I copied the [upstream implementation ](https://github.com/python/cpython/blob/8f943ca25732d548cf9f0b0393ba8d582fb93e29/Modules/_datetimemodule.c#L3994-L4009), and made the minimal modifications so that it would work outside of the cPython codebase.

---

In the process, I uncovered a few more latent bugs:

* You were able to call `utcoffset`, `dst`, and `tzname` without any parameters, which is wrong but went unnoticed since none of those methods actually use the parameters (and the methods were marked as [`METH_VARARGS` and not `METH_O`](https://docs.python.org/3/c-api/structures.html).
* `tzname` in Python 2.7 needs to return a `str`, when it was returning a `unicode`

### What should reviewers focus on?

🤷 