### PR TITLE
Fix PyPy 2 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 # Unreleased
 
-*
+* Fix the build for PyPy2 ([#116](https://github.com/closeio/ciso8601/pull/116))
 
 # 2.x.x
 

--- a/module.c
+++ b/module.c
@@ -17,7 +17,7 @@
 // https://foss.heptapod.net/pypy/pypy/-/merge_requests/826
 #ifdef PYPY_VERSION
     #define SUPPORTS_37_TIMEZONE_API \
-            (PYPY_VERSION_NUM >= 0x07030600)
+            (PYPY_VERSION_NUM >= 0x07030600) && PY_VERSION_AT_LEAST_37
 #else
     #define SUPPORTS_37_TIMEZONE_API \
             PY_VERSION_AT_LEAST_37

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -62,8 +62,9 @@ class ValidTimestampTestCase(unittest.TestCase):
         # PyPy added support for it in 7.3.6
 
         timestamp = '2018-01-01T00:00:00.00Z'
-        if (platform.python_implementation() == 'CPython' and sys.version_info >= (3, 7)) or \
-           (platform.python_implementation() == 'PyPy' and sys.pypy_version_info >= (7, 3, 6)):
+        if sys.version_info >= (3, 7) and \
+            (platform.python_implementation() == 'CPython'
+             or (platform.python_implementation() == 'PyPy' and sys.pypy_version_info >= (7, 3, 6))):
             self.assertIs(parse_datetime(timestamp).tzinfo, datetime.timezone.utc)
         else:
             self.assertIsInstance(parse_datetime(timestamp).tzinfo, FixedOffset)


### PR DESCRIPTION
### What are you trying to accomplish?

Fix the [build failure](https://app.circleci.com/pipelines/github/closeio/ciso8601/165/workflows/065d4f78-59a0-451f-8c82-7aeebffcf523/jobs/2192) for PyPy 2

This wasn't noticed as part of v2.2.0, since that version of PyPy hadn't yet been released (it had been merged, but not released).

### What approach did you choose and why?

The check for whether PyPy supported the cPython 3.7's Timezone API was insufficient. It was just checking the PyPy version number, which is something that both PyPy 2 and PyPy 3 share.

We also still need to check the Python version.

### What should reviewers focus on?

🤷 

### The impact of these changes

Builds will once again work for PyPy 2.

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->

...
