### PR TITLE
Add PyPy 3.8 to the CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - test_pypy:
           matrix:
             parameters:
-              python_version: ["2.7", "3.7"]
+              python_version: ["2.7", "3.7", "3.8"]
       - lint-rst
 
 jobs:


### PR DESCRIPTION
### What are you trying to accomplish?

While investigating the build failures, I discovered that PyPy 3.8 was released.

### What approach did you choose and why?

Simple addition of the version to the CI config.

### What should reviewers focus on?

🤷 

### The impact of these changes

We start testing against PyPy 3.8. We still don't officially support PyPy, but it's good to know if we accidentally break them. If it proves stable enough we can start officially supporting them.