### PR TITLE
Fix PyPy 3.7 support

### DIFF
--- a/module.c
+++ b/module.c
@@ -12,12 +12,16 @@
     ((PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 6) || PY_MAJOR_VERSION > 3)
 #define PY_VERSION_AT_LEAST_37 \
     ((PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 7) || PY_MAJOR_VERSION > 3)
+#define PY_VERSION_AT_LEAST_38 \
+    ((PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 8) || PY_MAJOR_VERSION > 3)
 
 // PyPy compatibility for cPython 3.7's Timezone API was added to PyPy 7.3.6
 // https://foss.heptapod.net/pypy/pypy/-/merge_requests/826
+// But was then reverted in 7.3.7 for PyPy 3.7: https://foss.heptapod.net/pypy/pypy/-/commit/eeeafcf905afa0f26049ac29dc00f5b295171f99
+// It is still present in 7.3.7 for PyPy 3.8+
 #ifdef PYPY_VERSION
     #define SUPPORTS_37_TIMEZONE_API \
-            (PYPY_VERSION_NUM >= 0x07030600) && PY_VERSION_AT_LEAST_37
+            (PYPY_VERSION_NUM >= 0x07030600) && PY_VERSION_AT_LEAST_38
 #else
     #define SUPPORTS_37_TIMEZONE_API \
             PY_VERSION_AT_LEAST_37

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -59,12 +59,12 @@ class ValidTimestampTestCase(unittest.TestCase):
 
     def test_returns_built_in_utc_if_available(self):
         # Python 3.7 added a built-in UTC object at the C level (`PyDateTime_TimeZone_UTC`)
-        # PyPy added support for it in 7.3.6
+        # PyPy added support for it in 7.3.6, but only for PyPy 3.8+
 
         timestamp = '2018-01-01T00:00:00.00Z'
         if sys.version_info >= (3, 7) and \
             (platform.python_implementation() == 'CPython'
-             or (platform.python_implementation() == 'PyPy' and sys.pypy_version_info >= (7, 3, 6))):
+             or (platform.python_implementation() == 'PyPy' and sys.version_info >= (3, 8) and sys.pypy_version_info >= (7, 3, 6))):
             self.assertIs(parse_datetime(timestamp).tzinfo, datetime.timezone.utc)
         else:
             self.assertIsInstance(parse_datetime(timestamp).tzinfo, FixedOffset)


### PR DESCRIPTION
### What are you trying to accomplish?

The build for PyPy 3.7 has been [failing](https://app.circleci.com/pipelines/github/closeio/ciso8601/175/workflows/346aa53f-c46a-41c0-997d-03ac8f8adbb0/jobs/2309), since PyPy 3.7 v7.3.7 [reverted support](https://foss.heptapod.net/pypy/pypy/-/commit/eeeafcf905afa0f26049ac29dc00f5b295171f99) for the `PyDateTime_TimeZone_UTC` API which they had [added in v7.3.6](https://foss.heptapod.net/pypy/pypy/-/merge_requests/826).

The revert only affects PyPy 3.7, not the new PyPy 3.8.

This PR changes the conditions under which we will try to use the `PyDateTime_TimeZone_UTC` API when building in PyPy.

### What approach did you choose and why?

Adjusted the conditions and added some more to the context comments.

### What should reviewers focus on?

🤷 

### The impact of these changes

Users of PyPy 3.7 still won't be able to use the builtin `PyDateTime_TimeZone_UTC`. 
Oh well. `ciso8601` will still work, just slightly slower.