### PR TITLE
2022 CI + Benchmarking refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,11 @@ version: 2.1
 workflows:
   workflow:
     jobs:
+      - test_python_34
       - test:
           matrix:
             parameters:
-              python_version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              python_version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_pypy:
           matrix:
             parameters:
@@ -14,6 +15,17 @@ workflows:
       - lint-rst
 
 jobs:
+  # `cimg/python` doesn't support Python 3.4,
+  # but old `circleci/python` is still around!
+  test_python_34:
+    steps:
+      - checkout
+      - run:
+          name: Test
+          command: python setup.py test
+    docker:
+      - image: circleci/python:3.4
+
   test:
     parameters:
       python_version:
@@ -24,7 +36,7 @@ jobs:
           name: Test
           command: python setup.py test
     docker:
-      - image: circleci/python:<<parameters.python_version>>
+      - image: cimg/python:<<parameters.python_version>>
 
   test_pypy:
     parameters:
@@ -54,4 +66,4 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-      - image: circleci/python:3.11
+      - image: cimg/python:3.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
       - test_pypy:
           matrix:
             parameters:
-              python_version: ["2.7", "3.7", "3.8"]
+              python_version: ["2.7", "3.7", "3.8", "3.9"]
       - lint-rst
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python_version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+              python_version: ["2.7", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       - test_pypy:
           matrix:
             parameters:
@@ -54,4 +54,4 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-      - image: circleci/python:3.10
+      - image: circleci/python:3.11

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - run: |
           pip install packaging
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Build sdist
         run: python setup.py sdist

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.
+Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11.
 
 **Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
 

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -5,20 +5,23 @@ RUN apt-get update && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update
 
-# Install the Python versions
-RUN apt install -y python python-dev && \
-    apt install -y python3.5 python3.5-dev python3.5-venv && \
-    apt install -y python3.6 python3.6-dev python3.6-venv && \
-    apt install -y python3.7 python3.7-dev python3.7-venv && \
-    apt install -y python3.8 python3.8-dev python3.8-venv && \
-    apt install -y python3.9 python3.9-dev python3.9-venv && \
-    apt install -y python3.10 python3.10-dev python3.10-venv
-
 # Install the other dependencies
 RUN apt-get install -y git curl gcc build-essential
 
-# Make Python 3.10 the default `python`
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10
+# Install tzdata non-iteractively
+# https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive/44333806#44333806
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+
+# Install the Python versions
+RUN apt install -y python2 python2-dev && \
+    apt install -y python3.7 python3.7-dev python3.7-venv && \
+    apt install -y python3.8 python3.8-dev python3.8-venv && \
+    apt install -y python3.9 python3.9-dev python3.9-venv && \
+    apt install -y python3.10 python3.10-dev python3.10-venv && \
+    apt install -y python3.11 python3.11-dev python3.11-venv
+
+# Make Python 3.11 the default `python`
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 10
 
 # Get pip
 RUN python -m ensurepip --upgrade

--- a/benchmarking/format_results.py
+++ b/benchmarking/format_results.py
@@ -5,6 +5,7 @@ import platform
 import re
 
 from collections import defaultdict, UserDict
+from packaging import version as version_parse
 
 import pytablewriter
 
@@ -64,9 +65,11 @@ def format_used_module_versions(module_versions_used):
         if len(versions) == 1:
             results.append(f"{module}=={next(iter(versions.keys()))}")
         else:
-            results.append(", ".join([f"{module}=={version} (on Python {', '.join(sorted(py_versions))})" for version, py_versions in versions.items()]))
+            results.append(", ".join([f"{module}=={version} (on Python {', '.join(version_sort(py_versions))})" for version, py_versions in versions.items()]))
     return results
 
+def version_sort(versions):
+    return [str(v) for v in sorted([version_parse.parse(v) for v in versions])]
 
 def relative_slowdown(subject, comparison):
     most_modern_common_version = next(iter(sorted(set(subject.keys()).intersection(set(comparison)), reverse=True)), None)

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -21,17 +21,18 @@ deps=
     # https://github.com/silverfernsys/iso8601utils/issues/6
     iso8601utils; python_version != '3.6' and python_version != '3.10'
     isodate
-    maya
+    ; `maya` uses a version of `regex` which no longer supports Python 2
+    maya; python_version > '3'
     metomi-isodatetime; python_version >= '3.5'
     ; `moment` is built on `times`, which is built on `arrow`, which no longer supports Python 3.4
-    moment; python_version != '3.4'
+    ; `moment` uses a version of `regex` which no longer supports Python 2
+    moment; python_version >= '3.5'
     pendulum
     pyso8601
     python-dateutil
     str2date
     ; `udatetime` doesn't support Windows
-    ; `udatetime` doesn't compile on Python 3.9 (https://github.com/freach/udatetime/issues/32)
-    udatetime; os_name != 'nt' and python_version < '3.9'
+    udatetime; os_name != 'nt'
     ; `zulu` v2.0.0+ no longer supports Python < 3.6
     zulu; python_version >= '3.6'
     pytz

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py39,py38,py37,py36,py35,py34,py27
+envlist = py311,py310,py39,py38,py37,py36,py35,py34,py27
 setupdir=..
 
 [testenv]

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37,py38,py39}-caching_{enabled,disabled}
+envlist = {py27,py34,py35,py36,py37,py38,py39,py310,py311}-caching_{enabled,disabled}
 
 [testenv]
 setenv =


### PR DESCRIPTION
### What are you trying to accomplish?

[Python 3.11 has been released.](https://docs.python.org/3.11/whatsnew/3.11.html)

Make sure that we're testing against it.

Refresh all the bits of our CI/benchmarking that are stale too.

### What approach did you choose and why?

Searched for references to "3.10" and added "3.11".

I also updating the benchmarks to:
* Include `datetime.datetime.fromisoformat` (Fixes #125)
* Remove versions of Python no longer supported by the benchmarking Dockerfile (3.5, 3.6)
* Remove `maya` and `moment` from Python 2.7 testing
* Re-add `udatetime` for modern Python versions (> 3.9), since they fixed [their bug](https://github.com/freach/udatetime/issues/32).

Since CicleCI isn't going to release Docker image for Python 3.11 under their old a `circleci/python` namespace, I migrated our Docker images to use their new `cimg/python` namespace (Fixes #127) . This didn't support Python 3.4, so I duplicated our existing config to continue supporting 3.4. Deprecating 3.4 support can be considered in a separate issue.

I also noted that PyPy 3.9 is out, so I added it to the CI.

### What should reviewers focus on?

I intentionally left out the updated benchmarks until I verify that `datetime.fromisoformat` really does cover all of ciso8601's subset. After that, I'll add the  new results and contextualize them.

(While `datetime.fromisoformat` is faster for timestamps **without a timezone**, our lean timezone implementation means that we are still faster for timestamps **with a timezone**)

It seems that the vast majority of Python users will no longer have a reason to use ciso8601. 🎉🖤

### The impact of these changes

Keeping up to date with the world of Python and CircleCI.