### PR TITLE
Add benchmarking for a performance lower bound

### DIFF
--- a/benchmarking/format_results.py
+++ b/benchmarking/format_results.py
@@ -99,6 +99,8 @@ def load_benchmarking_results(results_directory):
                 minor = int(minor)
                 timestamps.add(timestamp)
                 for module, _setup, stmt, parse_result, count, time_taken, matched, exception in reader:
+                    if module == "hardcoded":
+                        continue
                     timing = float(time_taken) / int(count) if exception == "" else None
                     exception = exception if exception != "" else None
                     results[module][(major, minor)] = Result(

--- a/benchmarking/perform_comparison.py
+++ b/benchmarking/perform_comparison.py
@@ -19,6 +19,7 @@ except ImportError:
 ISO_8601_MODULES = {
     "aniso8601": ("import aniso8601", "aniso8601.parse_datetime('{timestamp}')"),
     "ciso8601": ("import ciso8601", "ciso8601.parse_datetime('{timestamp}')"),
+    "hardcoded": ("import ciso8601", "ciso8601._hard_coded_benchmark_timestamp()"),
     "python-dateutil": ("import dateutil.parser", "dateutil.parser.parse('{timestamp}')"),
     "iso8601": ("import iso8601", "iso8601.parse_date('{timestamp}')"),
     "isodate": ("import isodate", "isodate.parse_datetime('{timestamp}')"),
@@ -142,7 +143,7 @@ def write_module_versions(filepath):
         module_version_writer = csv.writer(fout, delimiter=",", quotechar='"', lineterminator="\n")
         module_version_writer.writerow([sys.version_info.major, sys.version_info.minor])
         for module, (_setup, _stmt) in sorted(ISO_8601_MODULES.items(), key=lambda x: x[0].lower()):
-            if module == "datetime (builtin)":
+            if module == "datetime (builtin)" or module == "hardcoded":
                 continue
             module_version_writer.writerow([module, get_module_version(module)])
 

--- a/module.c
+++ b/module.c
@@ -554,6 +554,14 @@ parse_rfc3339(PyObject *self, PyObject *args)
     return _parse(self, args, 1, 1);
 }
 
+static PyObject *
+_hard_coded_benchmark_timestamp(PyObject *self, PyObject *ignored)
+{
+    return PyDateTimeAPI->DateTime_FromDateAndTime(
+        2014, 1, 9, 21, 48, 0, 0, Py_None,
+        PyDateTimeAPI->DateTimeType);
+}
+
 static PyMethodDef CISO8601Methods[] = {
     {"parse_datetime", parse_datetime, METH_VARARGS,
      "Parse a ISO8601 date time string."},
@@ -561,6 +569,8 @@ static PyMethodDef CISO8601Methods[] = {
      "Parse a ISO8601 date time string, ignoring the time zone component."},
     {"parse_rfc3339", parse_rfc3339, METH_VARARGS,
      "Parse an RFC 3339 date time string."},
+    {"_hard_coded_benchmark_timestamp", _hard_coded_benchmark_timestamp, METH_NOARGS,
+     "Return a datetime using hardcoded values (for benchmarking purposes)"},
     {NULL, NULL, 0, NULL}};
 
 #if PY_MAJOR_VERSION >= 3

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -7,7 +7,7 @@ import platform
 import re
 import sys
 
-from ciso8601 import FixedOffset, parse_datetime, parse_datetime_as_naive, parse_rfc3339
+from ciso8601 import _hard_coded_benchmark_timestamp, FixedOffset, parse_datetime, parse_datetime_as_naive, parse_rfc3339
 from generate_test_timestamps import generate_valid_timestamp_and_datetime, generate_invalid_timestamp
 
 if sys.version_info.major == 2:
@@ -542,6 +542,13 @@ class GithubIssueRegressionTestCase(unittest.TestCase):
             "20010203T04:05",
         )
 
+
+class HardCodedBenchmarkTimestampTestCase(unittest.TestCase):
+    def test_returns_expected_hardcoded_datetime(self):
+        self.assertEqual(
+            _hard_coded_benchmark_timestamp(),
+            datetime.datetime(2014, 1, 9, 21, 48, 0, 0),
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### What are you trying to accomplish?

How fast can `ciso8601` go? How close is it already to "optimal" performance?

We can see in the benchmarks that on the machine I test with, it takes ~130 nanoseconds (until #130 is merged) to parse a timestamp without time zone information.

But how fast can you go? 100 nanoseconds? 10 nanoseconds? 1 nanosecond?

### What approach did you choose and why?

In order to get a sense for how fast `ciso8601` could be, I've added a method that simply asks Python to initialize a `datetime` object using hardcoded values. This removes all parsing from the equation, and gives us an approximate lower bound for how fast `ciso8601` can go. So long as we're using Python's constructors to initialize the `datetime` object, we will never be faster than this.

I'm not yet exposing the results in the README (and perhaps never will), but would like to eventually include them in a new profiling document I'm drafting.

At any rate, here are the results on my machine:

| Method | Time taken |
|---------------------|-----------|
| `_hard_coded_benchmark_timestamp`         | 61.5 ns   |
| `parse_datetime('2014-01-09T21:48:00')` (v2.2.0)  | 130  ns   |

So we can see that `ciso8601` is within a factor of 2.1x of the lower bound.

(With #130, this factor much tighter 😏)

### What should reviewers focus on?

Any complaints about the name? I started it with an underscore to further indicate that one should not be using this / it's for internal use.

### The impact of these changes

We can collect data/benchmark this lower bound. Nothing user facing, unless they go looking at undocumented internal methods.