### PR TITLE
Remove unnecessary `unittest2` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     test_suite="tests",
     tests_require=[
         "pytz",
-        "unittest2 ; python_version < '3'",
     ],
     classifiers=[
         "Intended Audience :: Developers",

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,19 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import unittest
 
 from datetime import datetime, timedelta
 
 from ciso8601 import FixedOffset
 
 if sys.version_info.major == 2:
-    # We use unittest2 since it has a backport of the `unittest.TestCase.assertRaisesRegex` method,
-    # which is called `assertRaisesRegexp` in Python 2. This saves us the hassle of monkey-patching
-    # the class ourselves.
-    import unittest2 as unittest
-else:
-    import unittest
-
+    # We use add `unittest.TestCase.assertRaisesRegex` method, which is called `assertRaisesRegexp` in Python 2.
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 class TimezoneTestCase(unittest.TestCase):
     def test_utcoffset(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,17 +6,14 @@ import pickle
 import platform
 import re
 import sys
+import unittest
 
 from ciso8601 import FixedOffset, parse_datetime, parse_datetime_as_naive, parse_rfc3339
 from generate_test_timestamps import generate_valid_timestamp_and_datetime, generate_invalid_timestamp
 
 if sys.version_info.major == 2:
-    # We use unittest2 since it has a backport of the `unittest.TestCase.assertRaisesRegex` method,
-    # which is called `assertRaisesRegexp` in Python 2. This saves us the hassle of monkey-patching
-    # the class ourselves.
-    import unittest2 as unittest
-else:
-    import unittest
+    # We use add `unittest.TestCase.assertRaisesRegex` method, which is called `assertRaisesRegexp` in Python 2.
+    unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 
 class ValidTimestampTestCase(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,4 @@ setenv =
 deps =
     pytz
     nose
-    unittest2
 commands=nosetests


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #132

There was never a real need for this dependency.
as the comment describes, it was just there to provide to alias `assertRaisesRegexp` -> `assertRaisesRegex` in Python 2.7

It was introduced in [this commit](https://github.com/closeio/ciso8601/commit/7ec00a7b059fb3d610ee12e4269075169cf60506) (2018-05), and AFAICT, it was just me being a n00b.

### What approach did you choose and why?

There's a much simpler way to alias methods in Python.

### What should reviewers focus on?

Tests still pass.

### The impact of these changes

🔥 One less dependency. ✨ 