### PR TITLE
Release v2.3.0

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Verify that the `release_version` is larger/newer than the existing release in PyPI
         run: |
-          python -c 'import sys; from packaging import version; code = 0 if version.parse("${{ env.ciso8601_version }}") < version.parse("${{ env.release_version }}") else 1; sys.exit(code)'
+          python -c 'import sys; from packaging import version; code = 0 if version.parse("${{ env.pypi_version }}") < version.parse("${{ env.release_version }}") else 1; sys.exit(code)'
 
       - name: Verify that the `release_version` is present in the CHANGELOG
         # TODO: Use something like `changelog-cli` to extract the correct version number

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -71,7 +71,7 @@ jobs:
           echo -e "release_version=${{ env.release_version }}\nrelease_tag=${{ env.release_tag }}" > release_values.txt
 
       - name: Share normalized release values
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release_values
           path: release_values.txt
@@ -93,7 +93,7 @@ jobs:
           CIBW_SKIP: "pp*-macosx* *-win32 *-manylinux_i686"
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
 
@@ -112,7 +112,7 @@ jobs:
       - name: Build sdist
         run: python setup.py sdist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Unreleased](#unreleased)
 - [2.x.x](#2xx)
+  - [Version 2.3.0](#version-230)
   - [Version 2.2.0](#version-220)
   - [Version 2.1.3](#version-213)
   - [Version 2.1.2](#version-212)
@@ -20,6 +21,13 @@
 
 # Unreleased
 
+*
+
+# 2.x.x
+
+## Version 2.3.0
+
+* Added Python 3.11 support
 * Fix the build for PyPy2 ([#116](https://github.com/closeio/ciso8601/pull/116))
 * Added missing `fromutc` implementation for `FixedOffset` (#113). Thanks @davidkraljic
 * Removed improper ability to call `FixedOffset`'s `dst`, `tzname` and `utcoffset` without arguments
@@ -27,8 +35,6 @@
 * Change `METH_VARARGS` to `METH_O`, enhancing performance. ([#130](https://github.com/closeio/ciso8601/pull/130))
 * Added support for ISO week dates, ([#139](https://github.com/closeio/ciso8601/pull/139))
 * Added support for ordinal dates, ([#140](https://github.com/closeio/ciso8601/pull/140))
-
-# 2.x.x
 
 ## Version 2.2.0
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if os.environ.get("STRICT_WARNINGS", "0") == "1":
         os.environ["_CL_"] = ""
     os.environ["_CL_"] += " /WX"
 
-VERSION = "2.2.0"
+VERSION = "2.3.0"
 CISO8601_CACHING_ENABLED = int(os.environ.get('CISO8601_CACHING_ENABLED', '1') == '1')
 
 setup(


### PR DESCRIPTION
### What are you trying to accomplish?

New release to include the bug fixes from #113 and #116.
It also includes the performance improvements of #130
It also includes the spec coverage improvements of #139 and #140 

### What approach did you choose and why?

Bumping the version number and update the CHANGELOG. The usual.

I chose v2.3.0, since it expands the behaviour/scope of `ciso8601` (with ordinal-dates and week-dates)

As a fun aside, with #130, `ciso8601` is now 3x faster at parsing timestamps with time zone information than it was before v2.0.0