### PR TITLE
Simplify the decision tree with `backports.datetime_fromisoformat`

### DIFF
--- a/why_ciso8601.md
+++ b/why_ciso8601.md
@@ -7,7 +7,6 @@ This document aims to describe some considerations to make when choosing a times
 - [Do you care about the performance of timestamp parsing?](#do-you-care-about-the-performance-of-timestamp-parsing)
 - [Do you need strict RFC 3339 parsing?](#do-you-need-strict-rfc-3339-parsing)
 - [Are you OK with the subset of ISO 8601 supported by ciso8601?](#are-you-ok-with-the-subset-of-iso-8601-supported-by-ciso8601)
-- [Are you only parsing timestamps produced by `datetime.isoformat`?](#are-you-only-parsing-timestamps-produced-by-datetimeisoformat)
 - [Do you need to support Python \< 3.11?](#do-you-need-to-support-python--311)
 - [Do you need to support Python 2.7?](#do-you-need-to-support-python-27)
 
@@ -15,46 +14,36 @@ This document aims to describe some considerations to make when choosing a times
 
 ```mermaid
 graph TD;
-    A[Do you care about the performance of timestamp parsing?]
-    A--yes-->D;
-    A--no-->C;
     C[Do you need to support Python 2.7?];
     C--yes-->DD
     C--no-->E
+
     E[Do you need strict RFC 3339 parsing?];
     E--yes-->YY;
-    E--no-->G;
-    G[Are you only parsing timestamps produced by `datetime.isoformat`?]
-    G--yes-->F;
-    G--no-->H;
-    F[Do you need to support Python < 3.7?]
-    F--yes-->V;
-    F--no-->Z;
+    E--no-->AA;
+
+    AA[Do you care about the performance of timestamp parsing?]
+    AA--yes-->D;
+    AA--no-->H;
 
     H[Do you need to support Python < 3.11?]
+    H--yes-->V;
     H--no-->Z;
-    H--yes--->D;
 
     DD[Are you OK with the subset of ISO 8601 supported by ciso8601?]
     DD--no-->WW;
     DD--yes-->YY;
 
-
     D[Are you OK with the subset of ISO 8601 supported by ciso8601?]
-    D--no-->I;
-    D--yes--->Y;
-
-    I[Do you need to support Python < 3.11?]
-    I--yes-->W;
-    I--no-->ZZ;
+    D--yes-->Y;
+    D--no-->W;
 
     V[Use `backports.datetime_fromisoformat`]
     W[Use `pendulum.parsing.parse_iso8601`]
     WW[Use `pendulum.parsing.parse_iso8601`]
-    Y[Use `cis8601`]
-    YY[Use `cis8601`]
+    Y[Use `ciso8601`]
+    YY[Use `ciso8601`]
     Z[Use `datetime.fromisoformat`]
-    ZZ[Use `datetime.fromisoformat`]
 ```
 
 ## Do you care about the performance of timestamp parsing?
@@ -81,15 +70,11 @@ from pendulum.parsing import parse_iso8601
 parse_iso8601(timestamp)
 ```
 
-## Are you only parsing timestamps produced by `datetime.isoformat`?
-
-Since Python 3.7, `datetime.fromisoformat` supports parsing any timestamp output by `datetime.isoformat`, and the cPython implementation is [very performant](https://github.com/closeio/ciso8601#benchmark).
-
-If you need to support older versions of Python 3, consider [`backports.datetime_fromisoformat`](https://github.com/movermeyer/backports.datetime_fromisoformat).
-
 ## Do you need to support Python < 3.11?
 
 Since Python 3.11, `datetime.fromisoformat` supports parsing nearly any ISO 8601 timestamp, and the cPython implementation is [very performant](https://github.com/closeio/ciso8601#benchmark).
+
+If you need to support older versions of Python 3, consider [`backports.datetime_fromisoformat`](https://github.com/movermeyer/backports.datetime_fromisoformat).
 
 ## Do you need to support Python 2.7?
 


### PR DESCRIPTION
### What are you trying to accomplish?

Follow-up to https://github.com/closeio/ciso8601/pull/128

v2.0.0 of [`backports.datetime_fromisoformat` ](https://github.com/movermeyer/backports.datetime_fromisoformat) now backports Python 3.11's logic for `fromisoformat` (previously it backported Python 3.7's logic).

As a result, the decision tree of when to use which ISO 8601 parsing can be simplified.

### What approach did you choose and why?

Re-arranged the nodes in the decision tree to minimize the nodes/duplication.

### What should reviewers focus on?

You can see the rendered version of the document [here](https://github.com/closeio/ciso8601/blob/movermeyer/simplify_decision_tree/why_ciso8601.md).

Eventually, I'd love for the initial question to once again be "Do you care about the performance of timestamp parsing?":

```mermaid
graph TD;
    A[Do you care about the performance of timestamp parsing?]
    A--yes-->Y;
    A--no-->C;

    C[Do you need to support Python 2.7?];
    C--yes-->Y
    C--no-->E

    E[Do you need strict RFC 3339 parsing?];
    E--yes-->Y;
    E--no-->H;

    H[Do you need to support Python < 3.11?]
    H--yes-->V;
    H--no-->Z;

    V[Use `backports.datetime_fromisoformat`]
    Y[Use `ciso8601`]
    Z[Use `datetime.fromisoformat`]
```


But first we'd need to do https://github.com/closeio/ciso8601/issues/131

### The impact of these changes

Simpler graph. 