### PR TITLE
Add support for ISO week dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - [Version 2.0.0](#version-200)
     - [Breaking changes](#breaking-changes)
     - [Other Changes](#other-changes)
-    - [v1.x.x -> 2.0.0 Migration guide](#v1xx---200-migration-guide)
+    - [v1.x.x -\> 2.0.0 Migration guide](#v1xx---200-migration-guide)
       - [ValueError instead of None](#valueerror-instead-of-none)
       - [Tightened ISO 8601 conformance](#tightened-iso-8601-conformance)
       - [`parse_datetime_unaware` has been renamed](#parse_datetime_unaware-has-been-renamed)
@@ -25,6 +25,7 @@
 * Removed improper ability to call `FixedOffset`'s `dst`, `tzname` and `utcoffset` without arguments
 * Fixed: `datetime.tzname` returns a `str` in Python 2.7, not a `unicode`
 * Change `METH_VARARGS` to `METH_O`, enhancing performance. ([#130](https://github.com/closeio/ciso8601/pull/130))
+* Added support for ISO week dates, ([#139](https://github.com/closeio/ciso8601/pull/139))
 
 # 2.x.x
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE
 include README.rst
 include CHANGELOG.md
+include isocalendar.h
 include timezone.h

--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,15 @@ ciso8601
 Since it's written as a C module, it is much faster than other Python libraries.
 Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11.
 
-**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
+.. |datetime.fromisoformat| replace:: ``datetime.fromisoformat``
+.. _datetime.fromisoformat: https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
+
+**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec; but supports `a superset`_ of what is supported by Python itself (|datetime.fromisoformat|_).
 
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339
 
-.. _`only a popular subset`: https://github.com/closeio/ciso8601#supported-subset-of-iso-8601
+.. _`a superset`: https://github.com/closeio/ciso8601#supported-subset-of-iso-8601
 
 (Interested in working on projects like this? `Close`_ is looking for `great engineers`_ to join our team)
 
@@ -200,7 +203,8 @@ Tested on Linux 5.15.49-linuxkit using the following modules:
 
 .. </include:benchmark_module_versions.rst>
 
-**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec, `only a popular subset`_.
+**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec; but supports `a superset`_ of what is supported by Python itself (|datetime.fromisoformat|_).
+
 
 For full benchmarking details (or to run the benchmark yourself), see `benchmarking/README.rst`_
 
@@ -209,7 +213,7 @@ For full benchmarking details (or to run the benchmark yourself), see `benchmark
 Supported subset of ISO 8601
 ----------------------------
 
-``ciso8601`` only supports the most common subset of ISO 8601.
+``ciso8601`` only supports a subset of ISO 8601, but supports a superset of what is supported by Python itself (|datetime.fromisoformat|_), and supports the entirety of the `RFC 3339`_ specification.
 
 Date formats
 ^^^^^^^^^^^^
@@ -222,30 +226,20 @@ The following date formats are supported:
    ============================= ============== ==================
    Format                        Example        Supported
    ============================= ============== ==================
-   ``YYYY-MM-DD``                ``2018-04-29`` ✅
-   ``YYYY-MM``                   ``2018-04``    ✅
-   ``YYYYMMDD``                  ``20180429``   ✅
+   ``YYYY-MM-DD`` (extended)     ``2018-04-29`` ✅
+   ``YYYY-MM`` (extended)        ``2018-04``    ✅
+   ``YYYYMMDD`` (basic)          ``20180429``   ✅
+   ``YYYY-Www-D`` (week date)    ``2009-W01-1`` ✅
+   ``YYYY-Www`` (week date)      ``2009-W01``   ✅
+   ``YYYYWwwD`` (week date)      ``2009W011``   ✅
+   ``YYYYWww`` (week date)       ``2009W01``    ✅
+   ``YYYY-DDD`` (ordinal date)   ``1981-095``   ❌
+   ``YYYYDDD`` (ordinal date)    ``1981095``    ❌
    ``--MM-DD`` (omitted year)    ``--04-29``    ❌
    ``--MMDD`` (omitted year)     ``--0429``     ❌
    ``±YYYYY-MM`` (>4 digit year) ``+10000-04``  ❌
    ``+YYYY-MM`` (leading +)      ``+2018-04``   ❌
    ``-YYYY-MM`` (negative -)     ``-2018-04``   ❌
-   ============================= ============== ==================
-
-Week dates or ordinal dates are not currently supported.
-
-.. table::
-   :widths: auto
-
-   ============================= ============== ==================
-   Format                        Example        Supported
-   ============================= ============== ==================
-   ``YYYY-Www`` (week date)      ``2009-W01``   ❌
-   ``YYYYWww`` (week date)       ``2009W01``    ❌
-   ``YYYY-Www-D`` (week date)    ``2009-W01-1`` ❌
-   ``YYYYWwwD`` (week date)      ``2009-W01-1`` ❌
-   ``YYYY-DDD`` (ordinal date)   ``1981-095``   ❌
-   ``YYYYDDD`` (ordinal date)    ``1981095``    ❌
    ============================= ============== ==================
 
 Time formats

--- a/generate_test_timestamps.py
+++ b/generate_test_timestamps.py
@@ -228,25 +228,25 @@ def generate_invalid_timestamp(year=2014, month=2, day=3, iso_week=6, iso_day=1,
                     str_value = str(__pad_params(**{field_name: kwargs[field_name]})[field_name])[0:length]
                     mangled_kwargs[field_name] = "{{:0>{length}}}".format(length=length).format(str_value)
                     timestamp = timestamp_format.format(**mangled_kwargs)
-                    yield timestamp
+                    yield (timestamp, "{0} has too few characters".format(field_name))
 
                 # Too many characters
                 if field.max_width is not None:
                     mangled_kwargs[field_name] = "{{:0>{length}}}".format(length=field.max_width + 1).format(kwargs[field_name])
                     timestamp = timestamp_format.format(**mangled_kwargs)
-                    yield timestamp
+                    yield (timestamp, "{0} has too many characters".format(field_name))
 
                 # Too small of value
                 if (field.min_value - 1) >= 0:
                     mangled_kwargs[field_name] = __pad_params(**{field_name: field.min_value - 1})[field_name]
                     timestamp = timestamp_format.format(**mangled_kwargs)
-                    yield timestamp
+                    yield (timestamp, "{0} has too small value".format(field_name))
 
                 # Too large of value
                 if field.max_value is not None:
                     mangled_kwargs[field_name] = __pad_params(**{field_name: field.max_value + 1})[field_name]
                     timestamp = timestamp_format.format(**mangled_kwargs)
-                    yield timestamp
+                    yield (timestamp, "{0} has too large value".format(field_name))
 
                 # Invalid characters
                 max_invalid_characters = field.max_width if field.max_width is not None else 1
@@ -254,14 +254,14 @@ def generate_invalid_timestamp(year=2014, month=2, day=3, iso_week=6, iso_day=1,
                 for length in range(1, max_invalid_characters):
                     mangled_kwargs[field_name] = "a" * length
                     timestamp = timestamp_format.format(**mangled_kwargs)
-                    yield timestamp
+                    yield (timestamp, "{0} has invalid characters".format(field_name))
                 # ex. 2014 -> aaaa, 2aaa, 20aa, 201a
                 for length in range(0, max_invalid_characters):
                     str_value = str(__pad_params(**{field_name: kwargs[field_name]})[field_name])[0:length]
                     mangled_kwargs[field_name] = "{{:a<{length}}}".format(length=max_invalid_characters).format(str_value)
                     timestamp = timestamp_format.format(**mangled_kwargs)
-                    yield timestamp
+                    yield (timestamp, "{0} has invalid characters".format(field_name))
 
         # Trailing characters
         timestamp = timestamp_format.format(**__pad_params(**kwargs)) + "EXTRA"
-        yield timestamp
+        yield (timestamp, "{0} has extra characters".format(field_name))

--- a/isocalendar.c
+++ b/isocalendar.c
@@ -1,0 +1,280 @@
+/* This file was originally taken from cPython's code base
+ * (`Modules/_datetimemodule.c`) at commit
+ * 27d8dc2c9d3de886a884f79f0621d4586c0e0f7a
+ *
+ * Below is a copy of the Python 3.11 code license
+ * (from https://docs.python.org/3/license.html):
+ *
+ * PSF LICENSE AGREEMENT FOR PYTHON 3.11.0
+ *
+ * 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
+ *    the Individual or Organization ("Licensee") accessing and otherwise using Python
+ *    3.11.0 software in source or binary form and its associated documentation.
+ *
+ * 2. Subject to the terms and conditions of this License Agreement, PSF hereby
+ *    grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+ *    analyze, test, perform and/or display publicly, prepare derivative works,
+ *    distribute, and otherwise use Python 3.11.0 alone or in any derivative
+ *    version, provided, however, that PSF's License Agreement and PSF's notice of
+ *    copyright, i.e., "Copyright © 2001-2022 Python Software Foundation; All Rights
+ *    Reserved" are retained in Python 3.11.0 alone or in any derivative version
+ *    prepared by Licensee.
+ *
+ * 3. In the event Licensee prepares a derivative work that is based on or
+ *    incorporates Python 3.11.0 or any part thereof, and wants to make the
+ *    derivative work available to others as provided herein, then Licensee hereby
+ *    agrees to include in any such work a brief summary of the changes made to Python
+ *    3.11.0.
+ *
+ * 4. PSF is making Python 3.11.0 available to Licensee on an "AS IS" basis.
+ *    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
+ *    EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
+ *    WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
+ *    USE OF PYTHON 3.11.0 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+ *
+ * 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.11.0
+ *    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+ *    MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.11.0, OR ANY DERIVATIVE
+ *    THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+ *
+ * 6. This License Agreement will automatically terminate upon a material breach of
+ *    its terms and conditions.
+ *
+ * 7. Nothing in this License Agreement shall be deemed to create any relationship
+ *    of agency, partnership, or joint venture between PSF and Licensee.  This License
+ *    Agreement does not grant permission to use PSF trademarks or trade name in a
+ *    trademark sense to endorse or promote products or services of Licensee, or any
+ *    third party.
+ *
+ * 8. By copying, installing or otherwise using Python 3.11.0, Licensee agrees
+ *    to be bound by the terms and conditions of this License Agreement.
+ */
+
+#include "Python.h"
+#include "isocalendar.h"
+
+/* ---------------------------------------------------------------------------
+ * General calendrical helper functions
+ */
+
+/* For each month ordinal in 1..12, the number of days in that month,
+ * and the number of days before that month in the same year.  These
+ * are correct for non-leap years only.
+ */
+static const int _days_in_month[] = {
+    0, /* unused; this vector uses 1-based indexing */
+    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+};
+
+static const int _days_before_month[] = {
+    0, /* unused; this vector uses 1-based indexing */
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+};
+
+/* year -> 1 if leap year, else 0. */
+static int
+is_leap(int year)
+{
+    /* Cast year to unsigned.  The result is the same either way, but
+     * C can generate faster code for unsigned mod than for signed
+     * mod (especially for % 4 -- a good compiler should just grab
+     * the last 2 bits when the LHS is unsigned).
+     */
+    const unsigned int ayear = (unsigned int)year;
+    return ayear % 4 == 0 && (ayear % 100 != 0 || ayear % 400 == 0);
+}
+
+/* year, month -> number of days in that month in that year */
+static int
+days_in_month(int year, int month)
+{
+    assert(month >= 1);
+    assert(month <= 12);
+    if (month == 2 && is_leap(year))
+        return 29;
+    else
+        return _days_in_month[month];
+}
+
+/* year, month -> number of days in year preceding first day of month */
+static int
+days_before_month(int year, int month)
+{
+    int days;
+
+    assert(month >= 1);
+    assert(month <= 12);
+    days = _days_before_month[month];
+    if (month > 2 && is_leap(year))
+        ++days;
+    return days;
+}
+
+/* year -> number of days before January 1st of year.  Remember that we
+ * start with year 1, so days_before_year(1) == 0.
+ */
+static int
+days_before_year(int year)
+{
+    int y = year - 1;
+    /* This is incorrect if year <= 0; we really want the floor
+     * here.  But so long as MINYEAR is 1, the smallest year this
+     * can see is 1.
+     */
+    assert (year >= 1);
+    return y*365 + y/4 - y/100 + y/400;
+}
+
+/* Number of days in 4, 100, and 400 year cycles.  That these have
+ * the correct values is asserted in the module init function.
+ */
+#define DI4Y    1461    /* days_before_year(5); days in 4 years */
+#define DI100Y  36524   /* days_before_year(101); days in 100 years */
+#define DI400Y  146097  /* days_before_year(401); days in 400 years  */
+
+/* ordinal -> year, month, day, considering 01-Jan-0001 as day 1. */
+static void
+ord_to_ymd(int ordinal, int *year, int *month, int *day)
+{
+    int n, n1, n4, n100, n400, leapyear, preceding;
+
+    /* ordinal is a 1-based index, starting at 1-Jan-1.  The pattern of
+     * leap years repeats exactly every 400 years.  The basic strategy is
+     * to find the closest 400-year boundary at or before ordinal, then
+     * work with the offset from that boundary to ordinal.  Life is much
+     * clearer if we subtract 1 from ordinal first -- then the values
+     * of ordinal at 400-year boundaries are exactly those divisible
+     * by DI400Y:
+     *
+     *    D  M   Y            n              n-1
+     *    -- --- ----        ----------     ----------------
+     *    31 Dec -400        -DI400Y       -DI400Y -1
+     *     1 Jan -399         -DI400Y +1   -DI400Y      400-year boundary
+     *    ...
+     *    30 Dec  000        -1             -2
+     *    31 Dec  000         0             -1
+     *     1 Jan  001         1              0          400-year boundary
+     *     2 Jan  001         2              1
+     *     3 Jan  001         3              2
+     *    ...
+     *    31 Dec  400         DI400Y        DI400Y -1
+     *     1 Jan  401         DI400Y +1     DI400Y      400-year boundary
+     */
+    assert(ordinal >= 1);
+    --ordinal;
+    n400 = ordinal / DI400Y;
+    n = ordinal % DI400Y;
+    *year = n400 * 400 + 1;
+
+    /* Now n is the (non-negative) offset, in days, from January 1 of
+     * year, to the desired date.  Now compute how many 100-year cycles
+     * precede n.
+     * Note that it's possible for n100 to equal 4!  In that case 4 full
+     * 100-year cycles precede the desired day, which implies the
+     * desired day is December 31 at the end of a 400-year cycle.
+     */
+    n100 = n / DI100Y;
+    n = n % DI100Y;
+
+    /* Now compute how many 4-year cycles precede it. */
+    n4 = n / DI4Y;
+    n = n % DI4Y;
+
+    /* And now how many single years.  Again n1 can be 4, and again
+     * meaning that the desired day is December 31 at the end of the
+     * 4-year cycle.
+     */
+    n1 = n / 365;
+    n = n % 365;
+
+    *year += n100 * 100 + n4 * 4 + n1;
+    if (n1 == 4 || n100 == 4) {
+        assert(n == 0);
+        *year -= 1;
+        *month = 12;
+        *day = 31;
+        return;
+    }
+
+    /* Now the year is correct, and n is the offset from January 1.  We
+     * find the month via an estimate that's either exact or one too
+     * large.
+     */
+    leapyear = n1 == 3 && (n4 != 24 || n100 == 3);
+    assert(leapyear == is_leap(*year));
+    *month = (n + 50) >> 5;
+    preceding = (_days_before_month[*month] + (*month > 2 && leapyear));
+    if (preceding > n) {
+        /* estimate is too large */
+        *month -= 1;
+        preceding -= days_in_month(*year, *month);
+    }
+    n -= preceding;
+    assert(0 <= n);
+    assert(n < days_in_month(*year, *month));
+
+    *day = n + 1;
+}
+
+/* year, month, day -> ordinal, considering 01-Jan-0001 as day 1. */
+static int
+ymd_to_ord(int year, int month, int day)
+{
+    return days_before_year(year) + days_before_month(year, month) + day;
+}
+
+/* Day of week, where Monday==0, ..., Sunday==6.  1/1/1 was a Monday. */
+static int
+weekday(int year, int month, int day)
+{
+    return (ymd_to_ord(year, month, day) + 6) % 7;
+}
+
+/* Ordinal of the Monday starting week 1 of the ISO year.  Week 1 is the
+ * first calendar week containing a Thursday.
+ */
+static int
+iso_week1_monday(int year)
+{
+    int first_day = ymd_to_ord(year, 1, 1);     /* ord of 1/1 */
+    /* 0 if 1/1 is a Monday, 1 if a Tue, etc. */
+    int first_weekday = (first_day + 6) % 7;
+    /* ordinal of closest Monday at or before 1/1 */
+    int week1_monday  = first_day - first_weekday;
+
+    if (first_weekday > 3)      /* if 1/1 was Fri, Sat, Sun */
+        week1_monday += 7;
+    return week1_monday;
+}
+
+int
+iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
+           int *year, int *month, int *day) {
+    if (iso_week <= 0 || iso_week >= 53) {
+        int out_of_range = 1;
+        if (iso_week == 53) {
+            // ISO years have 53 weeks in it on years starting with a Thursday
+            // and on leap years starting on Wednesday
+            int first_weekday = weekday(iso_year, 1, 1);
+            if (first_weekday == 3 || (first_weekday == 2 && is_leap(iso_year))) {
+                out_of_range = 0;
+            }
+        }
+
+        if (out_of_range) {
+            return -2;
+        }
+    }
+
+    if (iso_day <= 0 || iso_day >= 8) {
+        return -3;
+    }
+
+    // Convert (Y, W, D) to (Y, M, D) in-place
+    int day_1 = iso_week1_monday(iso_year);
+
+    int day_offset = (iso_week - 1)*7 + iso_day - 1;
+
+    ord_to_ymd(day_1 + day_offset, year, month, day);
+    return 0;
+}

--- a/isocalendar.h
+++ b/isocalendar.h
@@ -1,0 +1,7 @@
+#ifndef ISO_CALENDER_H
+#define ISO_CALENDER_H
+
+int iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
+           int *year, int *month, int *day);
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     ext_modules=[
         Extension(
             "ciso8601",
-            sources=["module.c", "timezone.c"],
+            sources=["module.c", "timezone.c", "isocalendar.c"],
             define_macros=[
                 ("CISO8601_VERSION", VERSION),
                 ("CISO8601_CACHING_ENABLED", CISO8601_CACHING_ENABLED),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -72,12 +72,12 @@ class InvalidTimestampTestCase(unittest.TestCase):
     # See `generate_test_timestamps.generate_invalid_timestamp` for details.
 
     def test_parse_auto_generated_invalid_formats(self):
-        for timestamp in generate_invalid_timestamp():
+        for timestamp, reason in generate_invalid_timestamp():
             try:
-                with self.assertRaises(ValueError, msg="Timestamp '{0}' was supposed to be invalid, but parsing it didn't raise ValueError.".format(timestamp)):
+                with self.assertRaises(ValueError, msg="Timestamp '{0}' was supposed to be invalid ({1}), but parsing it didn't raise ValueError.".format(timestamp, reason)):
                     parse_datetime(timestamp)
             except Exception as exc:
-                print("Timestamp '{0}' was supposed to raise ValueError, but raised {1} instead".format(timestamp, type(exc).__name__))
+                print("Timestamp '{0}' was supposed to raise ValueError ({1}), but raised {2} instead".format(timestamp, reason, type(exc).__name__))
                 raise
 
     def test_non_ascii_characters(self):

--- a/why_ciso8601.md
+++ b/why_ciso8601.md
@@ -61,7 +61,7 @@ RFC 3339 can be (roughly) thought of as a subset of ISO 8601. If you need strict
 
 ## Are you OK with the subset of ISO 8601 supported by ciso8601?
 
-You probably are. `ciso8601` [supports the most commonly seen subset of ISO 8601 timestamps](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601).
+You probably are. `ciso8601` supports [the subset of ISO 8601](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601) that is supported by Python itself.
 
 If not, consider [`pendulum`](https://github.com/sdispater/pendulum)'s `parsing.parse_iso8601` instead:
 


### PR DESCRIPTION
### What are you trying to accomplish?

Partly addresses #131.

### What approach did you choose and why?

- Copied the helper methods from [cPython source](https://github.com/python/cpython/blob/27d8dc2c9d3de886a884f79f0621d4586c0e0f7a/Modules/_datetimemodule.c) into a new `isocalendar.c`
- Added the two new branches, by porting the upstream code 

- Updated the automatic test generation code: 
    - to support these cases 
    - to also return the reason that the timestamp is invalid. Useful for debugging.

I also had to exempt `iso_week` from the "too few characters" invalid test generation for cases where it was directly followed by `iso_day`. If you reduce the `iso_week` field to 1 character, then the following `iso_day` will make it into `YYYYWwD` which gets considered to be a valid  `YYYYWww` timestamp. We don't have this problem with non-week-date timestamps, since `YYYYMM` is not a valid timestamp format, and `day` is always two characters (so the equivalent `YYYYMD` cannot happen). Note that this isn't a problem change the parser, but the way the invalid test case generation code was working.

- Updated the docs since we now support the same subset as Python itself

### What should reviewers focus on?

Performance for non-week-date timestamps is imperceptibly impacted.

### The impact of these changes

`ciso8601` will now support the same subset of ISO 8601 as Python itself.