### PR TITLE
Add support for ordinal dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * Fixed: `datetime.tzname` returns a `str` in Python 2.7, not a `unicode`
 * Change `METH_VARARGS` to `METH_O`, enhancing performance. ([#130](https://github.com/closeio/ciso8601/pull/130))
 * Added support for ISO week dates, ([#139](https://github.com/closeio/ciso8601/pull/139))
+* Added support for ordinal dates, ([#140](https://github.com/closeio/ciso8601/pull/140))
 
 # 2.x.x
 

--- a/README.rst
+++ b/README.rst
@@ -16,15 +16,8 @@ ciso8601
 Since it's written as a C module, it is much faster than other Python libraries.
 Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11.
 
-.. |datetime.fromisoformat| replace:: ``datetime.fromisoformat``
-.. _datetime.fromisoformat: https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
-
-**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec; but supports `a superset`_ of what is supported by Python itself (|datetime.fromisoformat|_).
-
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339
-
-.. _`a superset`: https://github.com/closeio/ciso8601#supported-subset-of-iso-8601
 
 (Interested in working on projects like this? `Close`_ is looking for `great engineers`_ to join our team)
 
@@ -203,15 +196,15 @@ Tested on Linux 5.15.49-linuxkit using the following modules:
 
 .. </include:benchmark_module_versions.rst>
 
-**Note:** ciso8601 doesn't support the entirety of the ISO 8601 spec; but supports `a superset`_ of what is supported by Python itself (|datetime.fromisoformat|_).
-
-
 For full benchmarking details (or to run the benchmark yourself), see `benchmarking/README.rst`_
 
 .. _`benchmarking/README.rst`: https://github.com/closeio/ciso8601/blob/master/benchmarking/README.rst
 
 Supported subset of ISO 8601
 ----------------------------
+
+.. |datetime.fromisoformat| replace:: ``datetime.fromisoformat``
+.. _datetime.fromisoformat: https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
 
 ``ciso8601`` only supports a subset of ISO 8601, but supports a superset of what is supported by Python itself (|datetime.fromisoformat|_), and supports the entirety of the `RFC 3339`_ specification.
 
@@ -233,8 +226,18 @@ The following date formats are supported:
    ``YYYY-Www`` (week date)      ``2009-W01``   ✅
    ``YYYYWwwD`` (week date)      ``2009W011``   ✅
    ``YYYYWww`` (week date)       ``2009W01``    ✅
-   ``YYYY-DDD`` (ordinal date)   ``1981-095``   ❌
-   ``YYYYDDD`` (ordinal date)    ``1981095``    ❌
+   ``YYYY-DDD`` (ordinal date)   ``1981-095``   ✅
+   ``YYYYDDD`` (ordinal date)    ``1981095``    ✅
+   ============================= ============== ==================
+
+Uncommon ISO 8601 date formats are not supported:
+
+.. table::
+   :widths: auto
+
+   ============================= ============== ==================
+   Format                        Example        Supported
+   ============================= ============== ==================
    ``--MM-DD`` (omitted year)    ``--04-29``    ❌
    ``--MMDD`` (omitted year)     ``--0429``     ❌
    ``±YYYYY-MM`` (>4 digit year) ``+10000-04``  ❌

--- a/benchmarking/README.rst
+++ b/benchmarking/README.rst
@@ -7,9 +7,7 @@ Benchmarking ciso8601
 Introduction
 ------------
 
-``ciso8601``'s goal is to be the world's fastest ISO 8601 datetime parser for Python (**Note:** ciso8601 `only supports a subset of ISO 8601`_).
-
-.. _`only supports a subset of ISO 8601`: https://github.com/closeio/ciso8601#supported-subset-of-iso-8601
+``ciso8601``'s goal is to be the world's fastest ISO 8601 datetime parser for Python.
 
 In order to see how we compare, we run benchmarks against each other known ISO 8601 parser.
 

--- a/isocalendar.c
+++ b/isocalendar.c
@@ -68,7 +68,8 @@ static const int _days_in_month[] = {
 
 static const int _days_before_month[] = {
     0, /* unused; this vector uses 1-based indexing */
-    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334
+    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
+    365
 };
 
 /* year -> 1 if leap year, else 0. */
@@ -277,4 +278,45 @@ iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
 
     ord_to_ymd(day_1 + day_offset, year, month, day);
     return 0;
+}
+
+int
+ordinal_to_ymd(const int iso_year, int ordinal_day,
+           int *year, int *month, int *day) {
+
+    if (ordinal_day < 1){
+        return -1;
+    }
+
+    /* January */
+    if (ordinal_day <= _days_before_month[2]){
+        *year = iso_year;
+        *month = 1;
+        *day = ordinal_day - _days_before_month[1];
+        return 0;
+    }
+
+    /* February */
+    if (ordinal_day <= (_days_before_month[3] + (is_leap(iso_year) ? 1 : 0 ) )){
+        *year = iso_year;
+        *month = 2;
+        *day = ordinal_day - _days_before_month[2];
+        return 0;
+    }
+
+    if (is_leap(iso_year)){
+        ordinal_day -= 1;
+    }
+
+    /* March - December */
+    for (int i = 3; i <= 12; i++){
+        if (ordinal_day <= _days_before_month[i+1]){
+            *year = iso_year;
+            *month = i;
+            *day = ordinal_day - _days_before_month[i];
+            return 0;
+        }
+    }
+
+    return -2;
 }

--- a/isocalendar.h
+++ b/isocalendar.h
@@ -4,4 +4,7 @@
 int iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
            int *year, int *month, int *day);
 
+int ordinal_to_ymd(const int iso_year, const int ordinal_day,
+           int *year, int *month, int *day);
+
 #endif

--- a/why_ciso8601.md
+++ b/why_ciso8601.md
@@ -6,7 +6,6 @@ This document aims to describe some considerations to make when choosing a times
 
 - [Do you care about the performance of timestamp parsing?](#do-you-care-about-the-performance-of-timestamp-parsing)
 - [Do you need strict RFC 3339 parsing?](#do-you-need-strict-rfc-3339-parsing)
-- [Are you OK with the subset of ISO 8601 supported by ciso8601?](#are-you-ok-with-the-subset-of-iso-8601-supported-by-ciso8601)
 - [Do you need to support Python \< 3.11?](#do-you-need-to-support-python--311)
 - [Do you need to support Python 2.7?](#do-you-need-to-support-python-27)
 
@@ -14,35 +13,24 @@ This document aims to describe some considerations to make when choosing a times
 
 ```mermaid
 graph TD;
+    A[Do you care about the performance of timestamp parsing?]
+    A--yes-->Y;
+    A--no-->C;
+
     C[Do you need to support Python 2.7?];
-    C--yes-->DD
+    C--yes-->Y
     C--no-->E
 
     E[Do you need strict RFC 3339 parsing?];
-    E--yes-->YY;
-    E--no-->AA;
-
-    AA[Do you care about the performance of timestamp parsing?]
-    AA--yes-->D;
-    AA--no-->H;
+    E--yes-->Y;
+    E--no-->H;
 
     H[Do you need to support Python < 3.11?]
     H--yes-->V;
     H--no-->Z;
 
-    DD[Are you OK with the subset of ISO 8601 supported by ciso8601?]
-    DD--no-->WW;
-    DD--yes-->YY;
-
-    D[Are you OK with the subset of ISO 8601 supported by ciso8601?]
-    D--yes-->Y;
-    D--no-->W;
-
     V[Use `backports.datetime_fromisoformat`]
-    W[Use `pendulum.parsing.parse_iso8601`]
-    WW[Use `pendulum.parsing.parse_iso8601`]
     Y[Use `ciso8601`]
-    YY[Use `ciso8601`]
     Z[Use `datetime.fromisoformat`]
 ```
 
@@ -58,17 +46,6 @@ If you really, truly want to use the fastest parser, then `ciso8601` aims to be 
 ## Do you need strict RFC 3339 parsing?
 
 RFC 3339 can be (roughly) thought of as a subset of ISO 8601. If you need strict timestamp parsing that will complain if the given timestamp isn't strictly RFC 3339 compliant, then [`ciso8601` has a `parse_rfc3339` method](https://github.com/closeio/ciso8601#strict-rfc-3339-parsing).
-
-## Are you OK with the subset of ISO 8601 supported by ciso8601?
-
-You probably are. `ciso8601` supports [the subset of ISO 8601](https://github.com/closeio/ciso8601#supported-subset-of-iso-8601) that is supported by Python itself.
-
-If not, consider [`pendulum`](https://github.com/sdispater/pendulum)'s `parsing.parse_iso8601` instead:
-
-```python
-from pendulum.parsing import parse_iso8601
-parse_iso8601(timestamp)
-```
 
 ## Do you need to support Python < 3.11?
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #131 

Add support for ordinal dates. These are the "day number" of the year. January 1st is day 1 of every year. The numbers change for leap years, meaning that you can have day 366 on leap years.

### What approach did you choose and why?

- Added a new `ordinal_to_ymd` method in `isocalendar.c`
    - Chose this file since it gave me access to `_days_before_month` and didn't seem worth 
    - I didn't use the existing `ord_to_ymd`, since that is cPython's implementation that assumes an ordinal date starting at January 1 **year 1**, and doesn't reset each year
- Added the code to auto-generate ordinal date test cases, and added the new exemptions for the automated invalid test case generation
- Removed references to our "supported subset"

When I first took over maintainership and added these benchmarking scripts, there was [a comment from another parser maintainer](https://github.com/closeio/ciso8601/pull/55#issuecomment-395913155) that pointed out that it wasn't a fair comparison since the other parsers could parse more of the ISO 8601 spec. At the time, I addded these warnings/disclaimers throughout the code base.

But with this PR, we now support the same subset (or more) of ISO 8601 than the other parsers do. So I've removed the disclaimers, but kept the supported subset section. It's still there (no parser supports the full spec), but doesn't need to be called out specially anymore.

- Updated the decision tree to be simpler. Now there is no need to consider anything but `ciso8601`, `backports.datetime_fromisoformat`, or the builtin `datetime.fromisoformat`. 🎉  

### What should reviewers focus on?

You can see the rendered version of the document [here](https://github.com/closeio/ciso8601/blob/movermeyer/ordinal_dates/why_ciso8601.md).

Performance for non-ordinal timestamps is imperceptibly impacted.

### The impact of these changes

We no longer have to have disclaimers everywhere. The decision tree is simple.
Once a new release is done, we can update [the StackOverflow answer](https://stackoverflow.com/a/43054101)