### PR TITLE
Clang format again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
             parameters:
               python_version: ["2.7", "3.7", "3.8", "3.9"]
       - lint-rst
+      - clang-format
 
 jobs:
   # `cimg/python` doesn't support Python 3.4,
@@ -65,5 +66,29 @@ jobs:
           command: |
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
+    docker:
+      - image: cimg/python:3.11
+
+  clang-format:
+    working_directory: ~/code
+    steps:
+      - checkout
+      - run:
+          name: Install lint tools
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y clang-format
+      - run:
+          name: Lint
+          command: |
+            SOURCE_FILES=`find ./ -name \*.c -type f -or -name \*.h -type f`
+            for SOURCE_FILE in $SOURCE_FILES
+            do
+              export FORMATTING_ISSUE_COUNT=`clang-format -output-replacements-xml $SOURCE_FILE | grep offset | wc -l`
+              if [ "$FORMATTING_ISSUE_COUNT" -gt "0" ]; then
+                echo "Source file $SOURCE_FILE contains formatting issues. Please use clang-format tool to resolve found issues."
+                exit 1
+              fi
+            done
     docker:
       - image: cimg/python:3.11

--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@ BasedOnStyle: Google
 AlwaysBreakAfterReturnType: All
 AllowShortIfStatementsOnASingleLine: false
 AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: Consecutive
 BreakBeforeBraces: Stroustrup
 ColumnLimit: 79
 DerivePointerAlignment: false
@@ -12,6 +13,7 @@ Language: Cpp
 PointerAlignment: Right
 ReflowComments: true
 SpaceBeforeParens: ControlStatements
+SpacesBeforeTrailingComments: 2
 SpacesInParentheses: false
 TabWidth: 4
 UseTab: Never

--- a/generate_test_timestamps.py
+++ b/generate_test_timestamps.py
@@ -170,8 +170,8 @@ def generate_valid_timestamp_and_datetime(year=2014, month=2, day=3, iso_week=6,
     # Given a set of values, generates the 400+ different combinations of those values within a valid ISO 8601 string, and the corresponding datetime
     # This can be used to generate test cases of valid ISO 8601 timestamps.
 
-    # Note that this will produce many test cases that exercise the exact same code pathways (ie. offer no additional coverage).
-    # Given a knowledge of the code, this is excessive, but these serve as a good set of black box tests (ie. You could apply these to any ISO 8601 parse).
+    # Note that this will produce many test cases that exercise the exact same code pathways (i.e., offer no additional coverage).
+    # Given a knowledge of the code, this is excessive, but these serve as a good set of black box tests (i.e., You could apply these to any ISO 8601 parse).
 
     kwargs = {
         "year": year,
@@ -205,8 +205,8 @@ def generate_invalid_timestamp(year=2014, month=2, day=3, iso_week=6, iso_day=1,
     # This function takes each valid format (from `__generate_valid_formats()`), and mangles each field within the format to be invalid in each of the above ways.
     # It also tests the case of trailing characters after each format.
 
-    # Note that this will produce many test cases that exercise the exact same code pathways (ie. offer no additional coverage).
-    # Given a knowledge of the code, this is excessive, but these serve as a good set of black box tests (ie. You could apply these to any ISO 8601 parse).
+    # Note that this will produce many test cases that exercise the exact same code pathways (i.e., offer no additional coverage).
+    # Given a knowledge of the code, this is excessive, but these serve as a good set of black box tests (i.e., You could apply these to any ISO 8601 parse).
 
     # This does not produce every invalid timestamp format though. For simplicity of the code, it does not cover the cases of:
     #   - The fields having 0 characters (Many fields (like day, minute, second etc.) are optional. So unless the field follows a separator, it is valid to have 0 characters)

--- a/isocalendar.c
+++ b/isocalendar.c
@@ -7,51 +7,54 @@
  *
  * PSF LICENSE AGREEMENT FOR PYTHON 3.11.0
  *
- * 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"), and
- *    the Individual or Organization ("Licensee") accessing and otherwise using Python
- *    3.11.0 software in source or binary form and its associated documentation.
+ * 1. This LICENSE AGREEMENT is between the Python Software Foundation ("PSF"),
+ *    and the Individual or Organization ("Licensee") accessing and otherwise
+ *    using Python 3.11.0 software in source or binary form and its associated
+ *    documentation.
  *
  * 2. Subject to the terms and conditions of this License Agreement, PSF hereby
- *    grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
- *    analyze, test, perform and/or display publicly, prepare derivative works,
- *    distribute, and otherwise use Python 3.11.0 alone or in any derivative
- *    version, provided, however, that PSF's License Agreement and PSF's notice of
- *    copyright, i.e., "Copyright © 2001-2022 Python Software Foundation; All Rights
- *    Reserved" are retained in Python 3.11.0 alone or in any derivative version
- *    prepared by Licensee.
+ *    grants Licensee a nonexclusive, royalty-free, world-wide license to
+ *    reproduce, analyze, test, perform and/or display publicly, prepare
+ *    derivative works, distribute, and otherwise use Python 3.11.0 alone or in
+ *    any derivative version, provided, however, that PSF's License Agreement
+ *    and PSF's notice of copyright, i.e., "Copyright © 2001-2022 Python
+ *    Software Foundation; All Rights Reserved" are retained in Python 3.11.0
+ *    alone or in any derivative version prepared by Licensee.
  *
  * 3. In the event Licensee prepares a derivative work that is based on or
  *    incorporates Python 3.11.0 or any part thereof, and wants to make the
- *    derivative work available to others as provided herein, then Licensee hereby
- *    agrees to include in any such work a brief summary of the changes made to Python
- *    3.11.0.
+ *    derivative work available to others as provided herein, then Licensee
+ *    hereby agrees to include in any such work a brief summary of the changes
+ *    made to Python 3.11.0.
  *
  * 4. PSF is making Python 3.11.0 available to Licensee on an "AS IS" basis.
- *    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY OF
- *    EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY REPRESENTATION OR
- *    WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE
- *    USE OF PYTHON 3.11.0 WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
+ *    PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED.  BY WAY
+ *    OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND DISCLAIMS ANY
+ *    REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY
+ *    PARTICULAR PURPOSE OR THAT THE USE OF PYTHON 3.11.0 WILL NOT INFRINGE ANY
+ *    THIRD PARTY RIGHTS.
  *
  * 5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON 3.11.0
- *    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
- *    MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.11.0, OR ANY DERIVATIVE
- *    THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+ *    FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT
+ *    OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON 3.11.0, OR ANY
+ *    DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
  *
- * 6. This License Agreement will automatically terminate upon a material breach of
- *    its terms and conditions.
+ * 6. This License Agreement will automatically terminate upon a material
+ *    breach of its terms and conditions.
  *
- * 7. Nothing in this License Agreement shall be deemed to create any relationship
- *    of agency, partnership, or joint venture between PSF and Licensee.  This License
- *    Agreement does not grant permission to use PSF trademarks or trade name in a
- *    trademark sense to endorse or promote products or services of Licensee, or any
- *    third party.
+ * 7. Nothing in this License Agreement shall be deemed to create any
+ *    relationship of agency, partnership, or joint venture between PSF and
+ *    Licensee.  This License Agreement does not grant permission to use PSF
+ *    trademarks or trade name in a trademark sense to endorse or promote
+ *    products or services of Licensee, or any third party.
  *
  * 8. By copying, installing or otherwise using Python 3.11.0, Licensee agrees
  *    to be bound by the terms and conditions of this License Agreement.
  */
 
-#include "Python.h"
 #include "isocalendar.h"
+
+#include "Python.h"
 
 /* ---------------------------------------------------------------------------
  * General calendrical helper functions
@@ -63,13 +66,13 @@
  */
 static const int _days_in_month[] = {
     0, /* unused; this vector uses 1-based indexing */
-    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
 };
 
 static const int _days_before_month[] = {
     0, /* unused; this vector uses 1-based indexing */
-    0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
-    365
+    0,  31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334,
+    365  // Useful for month + 1 accesses for December
 };
 
 /* year -> 1 if leap year, else 0. */
@@ -122,16 +125,16 @@ days_before_year(int year)
      * here.  But so long as MINYEAR is 1, the smallest year this
      * can see is 1.
      */
-    assert (year >= 1);
-    return y*365 + y/4 - y/100 + y/400;
+    assert(year >= 1);
+    return y * 365 + y / 4 - y / 100 + y / 400;
 }
 
 /* Number of days in 4, 100, and 400 year cycles.  That these have
  * the correct values is asserted in the module init function.
  */
-#define DI4Y    1461    /* days_before_year(5); days in 4 years */
-#define DI100Y  36524   /* days_before_year(101); days in 100 years */
-#define DI400Y  146097  /* days_before_year(401); days in 400 years  */
+#define DI4Y   1461   /* days_before_year(5); days in 4 years */
+#define DI100Y 36524  /* days_before_year(101); days in 100 years */
+#define DI400Y 146097 /* days_before_year(401); days in 400 years  */
 
 /* ordinal -> year, month, day, considering 01-Jan-0001 as day 1. */
 static void
@@ -237,27 +240,29 @@ weekday(int year, int month, int day)
 static int
 iso_week1_monday(int year)
 {
-    int first_day = ymd_to_ord(year, 1, 1);     /* ord of 1/1 */
+    int first_day = ymd_to_ord(year, 1, 1); /* ord of 1/1 */
     /* 0 if 1/1 is a Monday, 1 if a Tue, etc. */
     int first_weekday = (first_day + 6) % 7;
     /* ordinal of closest Monday at or before 1/1 */
-    int week1_monday  = first_day - first_weekday;
+    int week1_monday = first_day - first_weekday;
 
-    if (first_weekday > 3)      /* if 1/1 was Fri, Sat, Sun */
+    if (first_weekday > 3) /* if 1/1 was Fri, Sat, Sun */
         week1_monday += 7;
     return week1_monday;
 }
 
 int
 iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
-           int *year, int *month, int *day) {
+           int *year, int *month, int *day)
+{
     if (iso_week <= 0 || iso_week >= 53) {
         int out_of_range = 1;
         if (iso_week == 53) {
             // ISO years have 53 weeks in it on years starting with a Thursday
             // and on leap years starting on Wednesday
             int first_weekday = weekday(iso_year, 1, 1);
-            if (first_weekday == 3 || (first_weekday == 2 && is_leap(iso_year))) {
+            if (first_weekday == 3 ||
+                (first_weekday == 2 && is_leap(iso_year))) {
                 out_of_range = 0;
             }
         }
@@ -274,22 +279,22 @@ iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
     // Convert (Y, W, D) to (Y, M, D) in-place
     int day_1 = iso_week1_monday(iso_year);
 
-    int day_offset = (iso_week - 1)*7 + iso_day - 1;
+    int day_offset = (iso_week - 1) * 7 + iso_day - 1;
 
     ord_to_ymd(day_1 + day_offset, year, month, day);
     return 0;
 }
 
 int
-ordinal_to_ymd(const int iso_year, int ordinal_day,
-           int *year, int *month, int *day) {
-
-    if (ordinal_day < 1){
+ordinal_to_ymd(const int iso_year, int ordinal_day, int *year, int *month,
+               int *day)
+{
+    if (ordinal_day < 1) {
         return -1;
     }
 
     /* January */
-    if (ordinal_day <= _days_before_month[2]){
+    if (ordinal_day <= _days_before_month[2]) {
         *year = iso_year;
         *month = 1;
         *day = ordinal_day - _days_before_month[1];
@@ -297,20 +302,20 @@ ordinal_to_ymd(const int iso_year, int ordinal_day,
     }
 
     /* February */
-    if (ordinal_day <= (_days_before_month[3] + (is_leap(iso_year) ? 1 : 0 ) )){
+    if (ordinal_day <= (_days_before_month[3] + (is_leap(iso_year) ? 1 : 0))) {
         *year = iso_year;
         *month = 2;
         *day = ordinal_day - _days_before_month[2];
         return 0;
     }
 
-    if (is_leap(iso_year)){
+    if (is_leap(iso_year)) {
         ordinal_day -= 1;
     }
 
     /* March - December */
-    for (int i = 3; i <= 12; i++){
-        if (ordinal_day <= _days_before_month[i+1]){
+    for (int i = 3; i <= 12; i++) {
+        if (ordinal_day <= _days_before_month[i + 1]) {
             *year = iso_year;
             *month = i;
             *day = ordinal_day - _days_before_month[i];

--- a/isocalendar.h
+++ b/isocalendar.h
@@ -1,10 +1,12 @@
 #ifndef ISO_CALENDER_H
 #define ISO_CALENDER_H
 
-int iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
+int
+iso_to_ymd(const int iso_year, const int iso_week, const int iso_day,
            int *year, int *month, int *day);
 
-int ordinal_to_ymd(const int iso_year, const int ordinal_day,
-           int *year, int *month, int *day);
+int
+ordinal_to_ymd(const int iso_year, const int ordinal_day, int *year,
+               int *month, int *day);
 
 #endif

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -122,7 +122,7 @@ class InvalidTimestampTestCase(unittest.TestCase):
         if sys.version_info >= (3, 3):
             self.assertRaisesRegex(
                 ValueError,
-                r"Invalid character while parsing date and time separator \(ie. 'T', 't', or ' '\) \('🐵', Index: 10\)",
+                r"Invalid character while parsing date and time separator \(i.e., 'T', 't', or ' '\) \('🐵', Index: 10\)",
                 parse_datetime,
                 "2019-01-01🐵01:02:03Z",
             )
@@ -163,7 +163,7 @@ class InvalidTimestampTestCase(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            r"Invalid character while parsing date and time separator \(ie. 'T', 't', or ' '\) \('2', Index: 8\)",
+            r"Invalid character while parsing date and time separator \(i.e., 'T', 't', or ' '\) \('2', Index: 8\)",
             parse_datetime,
             "2018-0102",
         )
@@ -353,7 +353,7 @@ class InvalidTimestampTestCase(unittest.TestCase):
     def test_invalid_date_and_time_separator(self):
         self.assertRaisesRegex(
             ValueError,
-            r"Invalid character while parsing date and time separator \(ie. 'T', 't', or ' '\) \('_', Index: 10\)",
+            r"Invalid character while parsing date and time separator \(i.e., 'T', 't', or ' '\) \('_', Index: 10\)",
             parse_datetime,
             "2018-01-01_00:00:00",
         )
@@ -584,7 +584,7 @@ class GithubIssueRegressionTestCase(unittest.TestCase):
     def test_issue_35(self):
         self.assertRaisesRegex(
             ValueError,
-            r"Invalid character while parsing date and time separator \(ie. 'T', 't', or ' '\) \('2', Index: 8\)",
+            r"Invalid character while parsing date and time separator \(i.e., 'T', 't', or ' '\) \('2', Index: 8\)",
             parse_datetime,
             "2017-0012-27T13:35:19+0200",
         )

--- a/timezone.c
+++ b/timezone.c
@@ -33,8 +33,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <datetime.h>
 #include <structmember.h>
 
-#define SECS_PER_MIN 60
-#define SECS_PER_HOUR (60 * SECS_PER_MIN)
+#define SECS_PER_MIN                 60
+#define SECS_PER_HOUR                (60 * SECS_PER_MIN)
 #define TWENTY_FOUR_HOURS_IN_SECONDS 86400
 
 #define PY_VERSION_AT_LEAST_36 \
@@ -46,7 +46,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 typedef struct {
     // Seconds offset from UTC.
     // Must be in range (-86400, 86400) seconds exclusive.
-    // ie. (-1440, 1440) minutes exclusive.
+    // i.e., (-1440, 1440) minutes exclusive.
     PyObject_HEAD int offset;
 } FixedOffset;
 


### PR DESCRIPTION
### What are you trying to accomplish?

Same as #141, except I merged #141 too fast after #140 and GitHub hadn't yet auto-rebased it onto `master`, so it was merged into `movermeyer/ordinal_dates` branch instead.

### What approach did you choose and why?

```
git cherry-pick ea7becff47e82199ee67253e1bbb93b339d3fe79
git cherry-pick 608476e2f54aca635b5be217423a46b2b37fa695
```

### What should reviewers focus on?
<!--
Outline anything you'd like reviewers to pay extra attention to. List open questions for discussion.
-->

...

### The impact of these changes

Actually merge these changes into `master`, instead of `movermeyer/ordinal_dates`
