### PR TITLE
Use latest versions of actions

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -11,9 +11,9 @@ jobs:
   sanity_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.11'
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build wheels
         uses: closeio/cibuildwheel@v2.11.3
@@ -102,9 +102,9 @@ jobs:
     needs: [sanity_check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: '3.11'


### PR DESCRIPTION
### What are you trying to accomplish?

GitHub Actions need to be upgraded in order to run.

<img width="1521" alt="image" src="https://user-images.githubusercontent.com/1459385/208981149-e1df8c17-e9e1-4ea2-957c-5ce8eff43ebf.png">

### What approach did you choose and why?

Bumped to the latest versions available.

### What should reviewers focus on?

🤷 The API hasn't changed in these versions, so the simple bump works without adjustment.

### The impact of these changes

We'll be able to run the workflow again.

### Testing

I [manually ran](https://github.com/closeio/ciso8601/actions/runs/3752018680) the Action against this PR. It worked, in that it ran. Failed the sanity check step since this PR isn't a release candidate PR.