### PR TITLE
Support for Python 3.12 and PyPy 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ workflows:
       - test:
           matrix:
             parameters:
-              python_version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              python_version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       - test_pypy:
           matrix:
             parameters:
-              python_version: ["2.7", "3.7", "3.8", "3.9"]
+              python_version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
       - lint-rst
       - clang-format
 
@@ -67,7 +67,7 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12
 
   clang-format:
     working_directory: ~/code
@@ -91,4 +91,4 @@ jobs:
               fi
             done
     docker:
-      - image: cimg/python:3.11
+      - image: cimg/python:3.12

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,7 +45,7 @@ jobs:
           echo 'VERSION in setup.py   `${{ env.ciso8601_version }}`'
           echo 'Version in PyPI       `${{ env.pypi_version }}`'
 
-      - name: Verify that  the version string we produced looks like a version string
+      - name: Verify that the version string we produced looks like a version string
         run: |
           echo "${{ env.release_version }}" | sed '/^[0-9]\+\.[0-9]\+\.[0-9]\+$/!{q1}'
 
@@ -109,8 +109,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Get build tool
+        run: pip install --upgrade build
+
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - run: |
           pip install packaging
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Build sdist
         run: python setup.py sdist

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11.
+Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12.
 
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -18,10 +18,11 @@ RUN apt install -y python2 python2-dev && \
     apt install -y python3.8 python3.8-dev python3.8-venv && \
     apt install -y python3.9 python3.9-dev python3.9-venv && \
     apt install -y python3.10 python3.10-dev python3.10-venv && \
-    apt install -y python3.11 python3.11-dev python3.11-venv
+    apt install -y python3.11 python3.11-dev python3.11-venv && \
+    apt install -y python3.12 python3.12-dev python3.12-venv
 
-# Make Python 3.11 the default `python`
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 10
+# Make Python 3.12 the default `python`
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.12 10
 
 # Get pip
 RUN python -m ensurepip --upgrade

--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -1,3 +1,3 @@
 importlib_metadata; python_version < '3.8'
 pytablewriter
-tox
+tox > 4

--- a/benchmarking/run_benchmarks.sh
+++ b/benchmarking/run_benchmarks.sh
@@ -1,5 +1,5 @@
-tox '2014-01-09T21:48:00'
-tox '2014-01-09T21:48:00-05:30'
+tox -- '2014-01-09T21:48:00'
+tox -- '2014-01-09T21:48:00-05:30'
 python format_results.py benchmark_results/2014-01-09T214800 benchmark_results/benchmark_with_no_time_zone.rst
 python format_results.py benchmark_results/2014-01-09T214800-0530 benchmark_results/benchmark_with_time_zone.rst
 python rst_include_replace.py ../README.rst 'benchmark_with_no_time_zone.rst' benchmark_results/benchmark_with_no_time_zone.rst

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -1,8 +1,11 @@
 [tox]
+requires =
+    tox>=4
 envlist = py312,py311,py310,py39,py38,py37,py36,py35,py34,py27
 setupdir=..
 
 [testenv]
+package = sdist
 setenv =
     CISO8601_CACHING_ENABLED = 1
 deps=

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311,py310,py39,py38,py37,py36,py35,py34,py27
+envlist = py312,py311,py310,py39,py38,py37,py36,py35,py34,py27
 setupdir=..
 
 [testenv]

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36,py37,py38,py39,py310,py311}-caching_{enabled,disabled}
+envlist = {py27,py34,py35,py36,py37,py38,py39,py310,py311,py312}-caching_{enabled,disabled}
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
+requires =
+    tox>=4
 envlist = {py27,py34,py35,py36,py37,py38,py39,py310,py311,py312}-caching_{enabled,disabled}
 
 [testenv]
+package = sdist
 setenv =
     STRICT_WARNINGS = 1
     caching_enabled: CISO8601_CACHING_ENABLED = 1


### PR DESCRIPTION
### What are you trying to accomplish?

Let's get CI working with the latest version of Python.

### What approach did you choose and why?

* Added Python 3.12 everywhere, and PyPy 3.10 to CI
* Migrated our tox configuration to the v4 syntax, as per their [migration guide](https://tox.wiki/en/4.11.3/upgrading.html)

### What should reviewers focus on?

🤷‍♂️. There's a new deprecation warning related to our use of the antiquated `python setup.py test`:

```
$ python setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
/home/mike/.pyenv/versions/3.12.0/lib/python3.12/site-packages/setuptools/command/test.py:193: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.
        ********************************************************************************

!!
  ir_d = dist.fetch_build_eggs(dist.install_requires)
WARNING: The wheel package is not available.
```

But getting a PEP 517-compliant builds and tests working in a way that supports all the old versions of Python that we support seems like a lot of work, so that'll be done in a [separate issue](https://github.com/closeio/ciso8601/issues/147).

### The impact of these changes

We'll be able to give confidence that `ciso8601` is still working on modern Python.
