### PR TITLE
Release v2.3.1

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: closeio/cibuildwheel@v2.11.3
+        uses: closeio/cibuildwheel@v2.16.2
         env:
           CIBW_SKIP: "pp*-macosx* *-win32 *-manylinux_i686"
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       requested_release_tag:
-        description: 'The tag to use for this release (e.g., `v2.3.0`)'
+        description: 'The tag to use for this release (e.g., `v2.3.1`)'
         required: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Unreleased](#unreleased)
 - [2.x.x](#2xx)
+  - [Version 2.3.1](#version-231)
   - [Version 2.3.0](#version-230)
   - [Version 2.2.0](#version-220)
   - [Version 2.1.3](#version-213)
@@ -24,6 +25,10 @@
 *
 
 # 2.x.x
+
+## Version 2.3.1
+
+* Added Python 3.12 wheels
 
 ## Version 2.3.0
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if os.environ.get("STRICT_WARNINGS", "0") == "1":
         os.environ["_CL_"] = ""
     os.environ["_CL_"] += " /WX"
 
-VERSION = "2.3.0"
+VERSION = "2.3.1"
 CISO8601_CACHING_ENABLED = int(os.environ.get('CISO8601_CACHING_ENABLED', '1') == '1')
 
 setup(


### PR DESCRIPTION
### What are you trying to accomplish?

New release for Python 2.3.1 wheels.

### What approach did you choose and why?

Bumped the patch version number.

### What should reviewers focus on?

You can verify the [commits made between since the last release](https://github.com/closeio/ciso8601/compare/v2.3.0...master) do not contain other changes.

### The impact of these changes

Users of Python 3.12 will have pre-built wheels. Fixes #146. 

### Testing

You can [download the artifacts](https://github.com/closeio/ciso8601/actions/runs/6644917223) and install them yourself in a local virtual environment.
