### PR TITLE
Release v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Unreleased](#unreleased)
 - [2.x.x](#2xx)
+  - [Version 2.3.2](#version-232)
   - [Version 2.3.1](#version-231)
   - [Version 2.3.0](#version-230)
   - [Version 2.2.0](#version-220)
@@ -22,12 +23,16 @@
 
 # Unreleased
 
+* Nil.
+
+# 2.x.x
+
+## Version 2.3.2
+
 * Add support for aarch64 wheels. Thank you @bbayles!
 * Add wheels for PyPy 3.10
 * Added Python 3.13 support
 * Better error message when attempting to parse a BCE year (#156). Thanks @javiabellan
-
-# 2.x.x
 
 ## Version 2.3.1
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if os.environ.get("STRICT_WARNINGS", "0") == "1":
         os.environ["_CL_"] = ""
     os.environ["_CL_"] += " /WX"
 
-VERSION = "2.3.1"
+VERSION = "2.3.2"
 CISO8601_CACHING_ENABLED = int(os.environ.get('CISO8601_CACHING_ENABLED', '1') == '1')
 
 setup(


### PR DESCRIPTION
### What are you trying to accomplish?

Release a new version of `ciso8601`, with support for aarch64 builds.

### What approach did you choose and why?

Bumped the version number and updated the CHANGELOG.

### What should reviewers focus on?

* [x] #151 bumped the version of the vendored `cibuildwheel` GitHub Action, so that will have to be bumped on the backend before the workflow will work.

### The impact of these changes

Users will be able to make use of pre-built aarch64 wheels, saving them from having to compile their own (saving time and having to install all the dependencies).