### PR TITLE
Python 3.13 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,22 +4,14 @@ workflows:
   workflow:
     jobs:
       - test_python_34
+      - test_old_pythons:
+          matrix:
+            parameters:
+              python_version: ["2.7", "3.5", "3.6", "3.7"]
       - test:
           matrix:
             parameters:
-              python_version:
-                [
-                  "2.7",
-                  "3.5",
-                  "3.6",
-                  "3.7",
-                  "3.8",
-                  "3.9",
-                  "3.10",
-                  "3.11",
-                  "3.12",
-                  "3.13",
-                ]
+              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
       - test_pypy:
           matrix:
             parameters:
@@ -39,7 +31,7 @@ jobs:
     docker:
       - image: circleci/python:3.4
 
-  test:
+  test_old_pythons:
     parameters:
       python_version:
         type: string
@@ -48,6 +40,21 @@ jobs:
       - run:
           name: Test
           command: python setup.py test
+    docker:
+      - image: cimg/python:<<parameters.python_version>>
+
+  test:
+    parameters:
+      python_version:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Test
+          # setuptools dropped support for being a test runner in v72.0.0
+          command: |
+            pip install --force-reinstall 'setuptools==71.1.0'
+            python setup.py test
     docker:
       - image: cimg/python:<<parameters.python_version>>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,19 @@ workflows:
       - test:
           matrix:
             parameters:
-              python_version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+              python_version:
+                [
+                  "2.7",
+                  "3.5",
+                  "3.6",
+                  "3.7",
+                  "3.8",
+                  "3.9",
+                  "3.10",
+                  "3.11",
+                  "3.12",
+                  "3.13",
+                ]
       - test_pypy:
           matrix:
             parameters:
@@ -67,7 +79,7 @@ jobs:
             . venv/bin/activate
             rst-lint --encoding=utf-8 README.rst
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.13
 
   clang-format:
     working_directory: ~/code
@@ -91,4 +103,4 @@ jobs:
               fi
             done
     docker:
-      - image: cimg/python:3.12
+      - image: cimg/python:3.13

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - run: |
           pip install packaging
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Get build tool
         run: pip install --upgrade build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 * Add support for aarch64 wheels. Thank you @bbayles!
 * Add wheels for PyPy 3.10
+* Added Python 3.13 support
 
 # 2.x.x
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ciso8601
 ``ciso8601`` converts `ISO 8601`_ or `RFC 3339`_ date time strings into Python datetime objects.
 
 Since it's written as a C module, it is much faster than other Python libraries.
-Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12.
+Tested with cPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13.
 
 .. _ISO 8601: https://en.wikipedia.org/wiki/ISO_8601
 .. _RFC 3339: https://tools.ietf.org/html/rfc3339

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -19,10 +19,11 @@ RUN apt install -y python2 python2-dev && \
     apt install -y python3.9 python3.9-dev python3.9-venv && \
     apt install -y python3.10 python3.10-dev python3.10-venv && \
     apt install -y python3.11 python3.11-dev python3.11-venv && \
-    apt install -y python3.12 python3.12-dev python3.12-venv
+    apt install -y python3.12 python3.12-dev python3.12-venv && \
+    apt install -y python3.13 python3.13-dev python3.13-venv
 
-# Make Python 3.12 the default `python`
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.12 10
+# Make Python 3.13 the default `python`
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10
 
 # Get pip
 RUN python -m ensurepip --upgrade
@@ -41,4 +42,4 @@ RUN git clone https://github.com/closeio/ciso8601.git && \
     chmod +x /ciso8601/benchmarking/run_benchmarks.sh
 
 WORKDIR /ciso8601/benchmarking
-ENTRYPOINT ./run_benchmarks.sh
+ENTRYPOINT ["bash", "./run_benchmarks.sh"]

--- a/benchmarking/Dockerfile
+++ b/benchmarking/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-get install -y git curl gcc build-essential
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
 
 # Install the Python versions
-RUN apt install -y python2 python2-dev && \
-    apt install -y python3.7 python3.7-dev python3.7-venv && \
+RUN apt install -y python3.7 python3.7-dev python3.7-venv && \
     apt install -y python3.8 python3.8-dev python3.8-venv && \
     apt install -y python3.9 python3.9-dev python3.9-venv && \
     apt install -y python3.10 python3.10-dev python3.10-venv && \

--- a/benchmarking/perform_comparison.py
+++ b/benchmarking/perform_comparison.py
@@ -168,7 +168,7 @@ def run_tests(timestamp, results_directory, compare_to):
     auto_range_count_filepath = os.path.join(results_directory, "auto_range_counts.csv")
     test_interation_counts = auto_range_counts(auto_range_count_filepath)
 
-    exec(ISO_8601_MODULES[compare_to][0])
+    exec(ISO_8601_MODULES[compare_to][0], globals())
     expected_parse_result = eval(ISO_8601_MODULES[compare_to][1].format(timestamp=timestamp))
 
     results = []
@@ -178,7 +178,7 @@ def run_tests(timestamp, results_directory, compare_to):
         time_taken = None
         exception = None
         try:
-            exec(setup)
+            exec(setup, globals())
             parse_result = eval(stmt.format(timestamp=timestamp))
 
             timer = timeit.Timer(stmt=stmt.format(timestamp=timestamp), setup=setup)

--- a/benchmarking/tox.ini
+++ b/benchmarking/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-envlist = py312,py311,py310,py39,py38,py37
+envlist = py313,py312,py311,py310,py39,py38,py37
 setupdir=..
 
 [testenv]

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )


### PR DESCRIPTION
### What are you trying to accomplish?

#155

Adding support for Python 3.13 

### What approach did you choose and why?

I added 3.13 everywhere. 

I had to adjust some calls to `exec` as a result of the `locals` [changes that happened in 3.13](https://peps.python.org/pep-0667/).
Otherwise the imports wouldn't result in changes to the `globals`, so subsequent calls wouldn't see the libraries as imported.

I also had to pin the version of `setuptools` to an old version, since they dropped support for being used as a test runner in v72 (#147).

### What should reviewers focus on?

🤷, once this is merged, I'll rebase #154, and we should be able to get 2.3.2 released 🤞. 

### The impact of these changes

We'll have Python 3.13 in our tests and our builds.