### PR TITLE
Remove unsupported backticks

### DIFF
--- a/why_ciso8601.md
+++ b/why_ciso8601.md
@@ -29,9 +29,9 @@ graph TD;
     H--yes-->V;
     H--no-->Z;
 
-    V[Use `backports.datetime_fromisoformat`]
-    Y[Use `ciso8601`]
-    Z[Use `datetime.fromisoformat`]
+    V[Use backports.datetime_fromisoformat]
+    Y[Use ciso8601]
+    Z[Use datetime.fromisoformat]
 ```
 
 ## Do you care about the performance of timestamp parsing?


### PR DESCRIPTION
### What are you trying to accomplish?

Sen on the [Why ciso8601?](https://github.com/closeio/ciso8601/blob/master/why_ciso8601.md) page:

<img width="423" alt="Screenshot 2024-11-09 at 22 16 23" src="https://github.com/user-attachments/assets/79357a5e-5572-49e0-a980-2e9d74724709">

Previously, one could include backticks in their node labels. However, [Mermaid v10.1.0 introduced "Markdown formatting"](https://docs.mermaidchart.com/blog/posts/automatic-text-wrapping-in-flowcharts-is-here) (which despite its name is not Markdown, but just Markdown-style bold and italics) which uses the backticks as part of its delimiters. This broke these labels.

---

<img width="183" alt="Screenshot 2024-11-09 at 22 35 44" src="https://github.com/user-attachments/assets/579a7885-3240-4d7b-835c-9dbb56565a65">

Also the "no" edges were being rendered as "n".


### What approach did you choose and why?

I've changed the labels to no longer use the backticks. 🤷
I quoted the `no` edge labels, so they render correctly.

### What should reviewers focus on?

🤷. CI is failing due to unrelated issues (fixed in #158) 

### The impact of these changes

Node/edge labels will render correctly once again.

### Testing

You can visit https://github.com/closeio/ciso8601/blob/movermeyer/diagram_fixup/why_ciso8601.md and see the rendered page with the fixes:

<img width="582" alt="Screenshot 2024-11-09 at 22 40 23" src="https://github.com/user-attachments/assets/9c87b475-a468-4a5c-83b1-756ad7022f92">

