### PR TITLE
Use `unittest` instead of `setuptools` (where possible)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,20 @@ workflows:
       - test_old_pythons:
           matrix:
             parameters:
-              python_version: ["2.7", "3.5", "3.6", "3.7"]
+              python_version: ["2.7", "3.5"]
       - test:
           matrix:
             parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+              python_version:
+                ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+      - test_old_pypy:
+          matrix:
+            parameters:
+              python_version: ["2.7"]
       - test_pypy:
           matrix:
             parameters:
-              python_version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - lint-rst
       - clang-format
 
@@ -31,7 +36,7 @@ jobs:
     docker:
       - image: circleci/python:3.4
 
-  test_old_pythons:
+  test_old_pythons: &old_python_tests
     parameters:
       python_version:
         type: string
@@ -43,30 +48,40 @@ jobs:
     docker:
       - image: cimg/python:<<parameters.python_version>>
 
-  test:
+  test_old_pypy:
+    <<: *old_python_tests
+    docker:
+      - image: pypy:<<parameters.python_version>>
+
+  test: &tests
     parameters:
       python_version:
         type: string
     steps:
       - checkout
       - run:
-          name: Test
-          # setuptools dropped support for being a test runner in v72.0.0
+          name: Install ciso8601
           command: |
-            pip install --force-reinstall 'setuptools==71.1.0'
-            python setup.py test
+            python -m venv venv
+            . venv/bin/activate
+            pip install --upgrade build
+            python -m build -s
+            pip install dist/ciso8601-*.tar.gz
+      - run:
+          name: Install testing dependencies
+          command: |
+            . venv/bin/activate
+            pip install pytz
+      - run:
+          name: Test
+          command: |
+            . venv/bin/activate
+            python -m unittest
     docker:
       - image: cimg/python:<<parameters.python_version>>
 
   test_pypy:
-    parameters:
-      python_version:
-        type: string
-    steps:
-      - checkout
-      - run:
-          name: Test
-          command: pypy setup.py test
+    <<: *tests
     docker:
       - image: pypy:<<parameters.python_version>>
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-envlist = {py27,py34,py35,py36,py37,py38,py39,py310,py311,py312}-caching_{enabled,disabled}
+envlist = {py313,py312,py311,py310,py39,py38}-caching_{enabled,disabled}
 
 [testenv]
 package = sdist
@@ -11,5 +11,4 @@ setenv =
     caching_disabled: CISO8601_CACHING_ENABLED = 0
 deps =
     pytz
-    nose
-commands=nosetests
+commands=python -m unittest


### PR DESCRIPTION
### What are you trying to accomplish?

`setuptools` has dropped its test-running capabilities in v72.
Python 3.12 dropped `setuptools` from the builtins.

My hope is that we'll be able to use PEP 517-compatible methods for testing on modern Pythons (#147), while still keeping the old `setup.py` method for old versions. We'll see.

### What approach did you choose and why?

If you are testing a pure-Python module, you can simply call `python -m unittest` to have your tests run.

However, since we're a compiled C-extension, we have to create the source distribution and install it first.

### What should reviewers focus on?

🤷 

### The impact of these changes

We are testing using the preferred method, at least for modern Pythons.