### PR TITLE
Better error message for BCE years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add support for aarch64 wheels. Thank you @bbayles!
 * Add wheels for PyPy 3.10
 * Added Python 3.13 support
+* Better error message when attempting to parse a BCE year (#156). Thanks @javiabellan
 
 # 2.x.x
 

--- a/module.c
+++ b/module.c
@@ -124,6 +124,14 @@ format_unexpected_character_exception(char *field_name, const char *c,
             field_name, expected_character_count,
             (expected_character_count != 1) ? "s" : "");
     }
+    else if (*c == '-' && index == 0 && strcmp(field_name, "year") == 0) {
+        PyErr_Format(
+            PyExc_ValueError,
+            "Invalid character while parsing %s ('-', Index: 0). "
+            "While valid ISO 8601 years, BCE years are not supported by "
+            "Python's `datetime` objects.",
+            field_name);
+    }
     else {
 #if PY_VERSION_AT_LEAST_33
         PyObject *unicode_str = PyUnicode_FromString(c);

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -446,6 +446,17 @@ class InvalidTimestampTestCase(unittest.TestCase):
             "20140102T01:02:03",
         )
 
+    def test_bce_years(self):
+        """
+        These are technically valid ISO 8601 datetimes.
+        However, cPython cannot support values non-positive year values
+        """
+        self.assertRaisesRegex(
+            ValueError,
+            r"Invalid character while parsing year \('-', Index: 0\). While valid ISO 8601 years, BCE years are not supported by Python's `datetime` objects.",
+            parse_datetime,
+            "-2014-01-02",
+        )
 
 class Rfc3339TestCase(unittest.TestCase):
     def test_valid_rfc3339_timestamps(self):


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #156 

### What approach did you choose and why?

Improved the error message specifically for the cases where someone attempts to parse BCE years.

### What should reviewers focus on?

🤷 Our performance guarantees are on the happy path. On the error path, we try to give the best error messages possible.

### The impact of these changes

Users will be be given a better error message in this specific case.

### Testing

```
>>> from ciso8601 import parse_datetime
>>> parse_datetime("-2014-01-02")
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    parse_datetime("-2014-01-02")
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
ValueError: Invalid character while parsing year ('-', Index: 0). While valid ISO 8601 years, BCE years are not supported by Python's `datetime` objects.
```
