### PR TITLE
Fix pypy compilation error

### DIFF
--- a/timezone.c
+++ b/timezone.c
@@ -83,7 +83,7 @@ FixedOffset_dst(FixedOffset *self, PyObject *dt)
 static PyObject *
 FixedOffset_fromutc(FixedOffset *self, PyDateTime_DateTime *dt)
 {
-    if (!PyDateTime_Check(dt)) {
+    if (!PyDateTime_Check((PyObject *)dt)) {
         PyErr_SetString(PyExc_TypeError,
                         "fromutc: argument must be a datetime");
         return NULL;


### PR DESCRIPTION
The existing Circle CI are failing on `main` ([example](https://app.circleci.com/jobs/github/closeio/ciso8601/4735?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification)). This Claude fix gets them green.

```
The issue is on line 86 in timezone.c:86. The function FixedOffset_fromutc is receiving
a PyDateTime_DateTime *dt parameter but PyPy's PyDateTime_Check expects a PyObject *.
The fix is to cast the parameter to PyObject *.
```