### PR TITLE
Build additional wheels on upgraded `cibuildwheel`

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           platforms: all
 
-      - uses: closeio/cibuildwheel@v2.20.0
+      - uses: closeio/cibuildwheel@v3.1.3
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -11,7 +11,7 @@ jobs:
   sanity_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         name: Install Python
@@ -85,7 +85,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up QEMU # Needed to build aarch64 wheels
         if: runner.os == 'Linux'
@@ -105,7 +105,7 @@ jobs:
     needs: [sanity_check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,14 @@ build = [
     "cp310-*",
     "cp311-*",
     "cp312-*",
+    "cp313-*",
+    "cp314-*",
     "pp38-*",
     "pp39-*",
     "pp310-*",
+    "pp311-*",
 ]
+enable = ["pypy", "pypy-eol"]
 
 [tool.cibuildwheel.linux]
 archs = ["x86_64", "aarch64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ skip = ["pp*"]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
-skip = ["pp*-win*", "*-win3"]
+skip = ["pp*-win*", "*-win32"]


### PR DESCRIPTION
Adds support for `cp313`, `cp314`, and `pp311` wheels.

The wheels happily built in this testing run: https://github.com/closeio/ciso8601/actions/runs/17080821189