### PR TITLE
Add support for building and testing ciso8601 on Windows ARM64

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -82,8 +82,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
+        include:
+          - os: ubuntu-latest
+          - os: windows-latest
+            cibw_archs: "AMD64"
+          - os: windows-11-arm
+            cibw_archs: "ARM64"
+          - os: macos-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -94,6 +99,8 @@ jobs:
           platforms: all
 
       - uses: closeio/cibuildwheel@v3.1.4
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,4 @@ environment = { MACOSX_DEPLOYMENT_TARGET="11.0" }
 skip = ["pp*"]
 
 [tool.cibuildwheel.windows]
-archs = ["AMD64"]
-skip = ["pp*-win*", "*-win32"]
+skip = ["pp*-win*", "*-win32", "cp39-win_arm64", "cp310-win_arm64"]


### PR DESCRIPTION
### What are you trying to accomplish?
<!--
Link to an issue or provide enough context so that someone new can understand the 'why' behind this change.
-->
* The PR adds CI support for building and releasing ciso8601 wheels for Windows ARM64
...

### The impact of these changes
<!--
Are there any specific impacts from this change that you'd like to call out?
-->
* There is no impact in the actual codebase, rather it just adds CI support for Windows ARM64, so that developers and users using this platform can be benefited.
...

### Testing
<!--
Are there any test results or screenshots that would be useful to include? How can a reviewer try out your change?
-->
* All test cases were passing as expected
...
